### PR TITLE
add default server role; bug fix

### DIFF
--- a/pgcat.toml
+++ b/pgcat.toml
@@ -69,3 +69,15 @@ servers = [
     # [ "127.0.1.1", 5432, "replica" ],
 ]
 database = "shard2"
+
+
+# Settings for our query routing layer.
+[query_router]
+
+# If the client doesn't specify, route traffic to
+# this role by default.
+#
+# any: round-robin between primary and replicas,
+# replica: round-robin between replicas only without touching the primary,
+# primary: all queries go to the primary unless otherwise specified.
+default_role = "any"

--- a/src/config.rs
+++ b/src/config.rs
@@ -44,10 +44,16 @@ pub struct Shard {
 }
 
 #[derive(Deserialize, Debug, Clone)]
+pub struct QueryRouter {
+    pub default_role: String,
+}
+
+#[derive(Deserialize, Debug, Clone)]
 pub struct Config {
     pub general: General,
     pub user: User,
     pub shards: HashMap<String, Shard>,
+    pub query_router: QueryRouter,
 }
 
 /// Parse the config.
@@ -118,6 +124,19 @@ pub async fn parse(path: &str) -> Result<Config, Error> {
         }
     }
 
+    match config.query_router.default_role.as_ref() {
+        "any" => (),
+        "primary" => (),
+        "replica" => (),
+        other => {
+            println!(
+                "> Query router default_role must be 'primary', 'replica', or 'any', got: '{}'",
+                other
+            );
+            return Err(Error::BadConfig);
+        }
+    };
+
     Ok(config)
 }
 
@@ -132,5 +151,6 @@ mod test {
         assert_eq!(config.shards.len(), 3);
         assert_eq!(config.shards["1"].servers[0].0, "127.0.0.1");
         assert_eq!(config.shards["0"].servers[0].2, "primary");
+        assert_eq!(config.query_router.default_role, "any");
     }
 }

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -124,10 +124,7 @@ impl ConnectionPool {
         // Make sure if a specific role is requested, it's available in the pool.
         match role {
             Some(role) => {
-                let role_count = addresses
-                    .iter()
-                    .filter(|&db| db.role == Role::Primary)
-                    .count();
+                let role_count = addresses.iter().filter(|&db| db.role == role).count();
 
                 if role_count == 0 {
                     println!(


### PR DESCRIPTION
### Features
1. Added `query_router.default_role` setting. Allows to route queries to primary, replicas, or any server by default, unless the client specifies a role explicitly using our custom syntax.

### Bug fixes
1. `ConnectionPool::get` required a primary to be configured when selecting a role explicitly, which was incorrect.