### PR TITLE
Pass real server info to the client

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -63,6 +63,7 @@ impl Client {
         client_server_map: ClientServerMap,
         transaction_mode: bool,
         default_server_role: Option<Role>,
+        server_info: BytesMut,
     ) -> Result<Client, Error> {
         loop {
             // Could be StartupMessage or SSLRequest
@@ -102,7 +103,7 @@ impl Client {
                     let secret_key: i32 = rand::random();
 
                     auth_ok(&mut stream).await?;
-                    server_parameters(&mut stream).await?;
+                    write_all(&mut stream, server_info).await?;
                     backend_key_data(&mut stream, process_id, secret_key).await?;
                     ready_for_query(&mut stream).await?;
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -90,6 +90,11 @@ pub async fn parse(path: &str) -> Result<Config, Error> {
         let mut dup_check = HashSet::new();
         let mut primary_count = 0;
 
+        if shard.1.servers.len() == 0 {
+            println!("> Shard {} has no servers configured", shard.0);
+            return Err(Error::BadConfig);
+        }
+
         for server in &shard.1.servers {
             dup_check.insert(server);
 

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -8,10 +8,8 @@ use crate::errors::Error;
 
 // This is a funny one. `psql` parses this to figure out which
 // queries to send when using shortcuts, e.g. \d+.
-//
-// TODO: Actually get the version from the server itself.
-//
-const SERVER_VESION: &str = "12.9 (Ubuntu 12.9-0ubuntu0.20.04.1)";
+// No longer used. Keeping it here until I'm sure we don't need it again.
+const _SERVER_VESION: &str = "12.9 (Ubuntu 12.9-0ubuntu0.20.04.1)";
 
 /// Tell the client that authentication handshake completed successfully.
 pub async fn auth_ok(stream: &mut TcpStream) -> Result<(), Error> {
@@ -27,12 +25,12 @@ pub async fn auth_ok(stream: &mut TcpStream) -> Result<(), Error> {
 /// Send server parameters to the client. This will tell the client
 /// what server version and what's the encoding we're using.
 //
-// TODO: Forward these from the server instead of hardcoding.
+// No longer used. Keeping it here until I'm sure we don't need it again.
 //
-pub async fn server_parameters(stream: &mut TcpStream) -> Result<(), Error> {
+pub async fn _server_parameters(stream: &mut TcpStream) -> Result<(), Error> {
     let client_encoding = BytesMut::from(&b"client_encoding\0UTF8\0"[..]);
     let server_version =
-        BytesMut::from(&format!("server_version\0{}\0", SERVER_VESION).as_bytes()[..]);
+        BytesMut::from(&format!("server_version\0{}\0", _SERVER_VESION).as_bytes()[..]);
 
     // Client encoding
     let len = client_encoding.len() as i32 + 4; // TODO: add more parameters here


### PR DESCRIPTION
### Features
1. On startup, connect to a server in each shard configuration to validate connection pool config.

### Bug fixes
1. Pass real server info to the client on startup (`S` backend message) instead of hardcoded server version and encoding.