### PR TITLE
More query router commands; settings last until changed again; docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ To select the shard we want to talk to, we introduced special syntax:
 SET SHARDING KEY TO '1234';
 ```
 
-This sharding key will be hashed and the pooler will select a shard to use for the next transaction. If the pooler is in session mode, this sharding key has to be set as the first query on startup & cannot be changed until the client re-connects.
+This sharding key will be hashed and the pooler will select a shard to use until the key or shard is set again. If the pooler is in session mode, this sharding key has to be set as the first query on startup & cannot be changed until the client re-connects.
 
 ### Explicit read/write query routing
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,20 @@ Meow. PgBouncer rewritten in Rust, with sharding, load balancing and failover su
 
 **Alpha**: don't use in production just yet.
 
+## Features
+
+| **Feature**                    | **Status**         | **Comments**                                                                                                                                          |
+|--------------------------------|--------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Transaction pooling            | :heavy_check_mark: | Identical to PgBouncer.                                                                                                                               |
+| Session pooling                | :heavy_check_mark: | Identical to PgBouncer.                                                                                                                               |
+| `COPY` support                 | :heavy_check_mark: | Both `COPY TO` and `COPY FROM` are supported.                                                                                                         |
+| Query cancellation             | :heavy_check_mark: | Supported both in transaction and session pooling modes.                                                                                              |
+| Load balancing of read queries | :heavy_check_mark: | Using round-robin between replicas. Primary is included when `primary_reads_enabled` is enabled (default).                                            |
+| Sharding                       | :heavy_check_mark: | Transactions are sharded using `SET SHARD TO` and `SET SHARDING KEY TO` syntax extensions; see examples below.                                        |
+| Failover                       | :heavy_check_mark: | Replicas are tested with a health check. If a health check fails, remaining replicas are attempted; see below for algorithm description and examples. |
+| Statistics reporting           | :heavy_check_mark: | Statistics similar to PgBouncers are reported via StatsD.                                                                                             |
+| Live configuration reloading   | :x: :wrench:       | On the roadmap; currently config changes require restart.                                                                                             |
+
 ## Local development
 
 1. Install Rust (latest stable will work great).

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Meow. PgBouncer rewritten in Rust, with sharding, load balancing and failover su
 
 ## Deployment
 
-See [`Dockerfile`]('./Dockerfile') for example deployment using Docker. The pooler is configured to spawn 4 workers so 4 CPUs are recommended for optimal performance.
+See `Dockerfile` for example deployment using Docker. The pooler is configured to spawn 4 workers so 4 CPUs are recommended for optimal performance.
 That setting can be adjusted to spawn as many (or as little) workers as needed.
 
 ## Local development

--- a/src/client.rs
+++ b/src/client.rs
@@ -228,7 +228,6 @@ impl Client {
                     println!(">> Could not get connection from pool: {:?}", err);
                     error_response(&mut self.write, "could not get connection from the pool")
                         .await?;
-                    query_router.reset();
                     continue;
                 }
             };
@@ -310,9 +309,6 @@ impl Client {
                             if self.transaction_mode {
                                 // Report this client as idle.
                                 self.stats.client_idle();
-
-                                query_router.reset();
-
                                 break;
                             }
                         }
@@ -395,9 +391,6 @@ impl Client {
 
                             if self.transaction_mode {
                                 self.stats.client_idle();
-
-                                query_router.reset();
-
                                 break;
                             }
                         }
@@ -431,8 +424,7 @@ impl Client {
                             self.stats.transaction();
 
                             if self.transaction_mode {
-                                query_router.reset();
-
+                                self.stats.client_idle();
                                 break;
                             }
                         }

--- a/src/client.rs
+++ b/src/client.rs
@@ -14,7 +14,7 @@ use crate::constants::*;
 use crate::errors::Error;
 use crate::messages::*;
 use crate::pool::{ClientServerMap, ConnectionPool};
-use crate::query_router::QueryRouter;
+use crate::query_router::{Command, QueryRouter};
 use crate::server::Server;
 use crate::stats::Reporter;
 
@@ -198,27 +198,48 @@ impl Client {
             // SET SHARDING KEY TO 'bigint';
             let mut message = read_message(&mut self.read).await?;
 
-            // Parse for special select shard command.
-            // SET SHARDING KEY TO 'bigint';
-            if query_router.select_shard(message.clone()) {
-                custom_protocol_response_ok(
+            // Handle all custom protocol commands here.
+            match query_router.try_parse_command(message.clone()) {
+                // Normal query
+                None => {
+                    if query_router.query_parser_enabled() && query_router.role() == None {
+                        query_router.infer_role(message.clone());
+                    }
+                }
+
+                Some((Command::SetShard, _)) | Some((Command::SetShardingKey, _)) => {
+                    custom_protocol_response_ok(&mut self.write, &format!("SET SHARD")).await?;
+                    continue;
+                }
+
+                Some((Command::SetServerRole, _)) => {
+                    custom_protocol_response_ok(&mut self.write, "SET SERVER ROLE").await?;
+                    continue;
+                }
+
+                Some((Command::ShowServerRole, value)) => {
+                    show_response(&mut self.write, "server role", &value).await?;
+                    continue;
+                }
+
+                Some((Command::ShowShard, value)) => {
+                    show_response(&mut self.write, "shard", &value).await?;
+                    continue;
+                }
+            };
+
+            // Make sure we selected a valid shard.
+            if query_router.shard() >= pool.shards() {
+                error_response(
                     &mut self.write,
-                    &format!("SET SHARD TO {}", query_router.shard()),
+                    &format!(
+                        "shard '{}' is more than configured '{}'",
+                        query_router.shard(),
+                        pool.shards()
+                    ),
                 )
                 .await?;
                 continue;
-            }
-
-            // Parse for special server role selection command.
-            // SET SERVER ROLE TO '(primary|replica)';
-            if query_router.select_role(message.clone()) {
-                custom_protocol_response_ok(&mut self.write, "SET SERVER ROLE").await?;
-                continue;
-            }
-
-            // Attempt to parse the query to determine where it should go
-            if query_router.query_parser_enabled() && query_router.role() == None {
-                query_router.infer_role(message.clone());
             }
 
             // Grab a server from the pool: the client issued a regular query.

--- a/src/client.rs
+++ b/src/client.rs
@@ -199,7 +199,7 @@ impl Client {
             let mut message = read_message(&mut self.read).await?;
 
             // Handle all custom protocol commands here.
-            match query_router.try_parse_command(message.clone()) {
+            match query_router.try_execute_command(message.clone()) {
                 // Normal query
                 None => {
                     if query_router.query_parser_enabled() && query_router.role() == None {

--- a/src/query_router.rs
+++ b/src/query_router.rs
@@ -82,7 +82,8 @@ impl QueryRouter {
         }
     }
 
-    pub fn try_parse_command(&mut self, mut buf: BytesMut) -> Option<(Command, String)> {
+    /// Try to parse a command and execute it.
+    pub fn try_execute_command(&mut self, mut buf: BytesMut) -> Option<(Command, String)> {
         let code = buf.get_u8() as char;
 
         if code != 'Q' {

--- a/src/query_router.rs
+++ b/src/query_router.rs
@@ -409,14 +409,14 @@ mod test {
     }
 
     #[test]
-    fn test_try_parse_command() {
+    fn test_try_execute_command() {
         QueryRouter::setup();
         let mut qr = QueryRouter::new(Some(Role::Primary), 5, false, false);
 
         // SetShardingKey
         let query = simple_query("SET SHARDING KEY TO '13'");
         assert_eq!(
-            qr.try_parse_command(query),
+            qr.try_execute_command(query),
             Some((Command::SetShardingKey, String::from("3")))
         );
         assert_eq!(qr.shard(), 3);
@@ -424,7 +424,7 @@ mod test {
         // SetShard
         let query = simple_query("SET SHARD TO '1'");
         assert_eq!(
-            qr.try_parse_command(query),
+            qr.try_execute_command(query),
             Some((Command::SetShard, String::from("1")))
         );
         assert_eq!(qr.shard(), 1);
@@ -432,7 +432,7 @@ mod test {
         // ShowShard
         let query = simple_query("SHOW SHARD");
         assert_eq!(
-            qr.try_parse_command(query),
+            qr.try_execute_command(query),
             Some((Command::ShowShard, String::from("1")))
         );
 
@@ -450,7 +450,7 @@ mod test {
         for (idx, role) in roles.iter().enumerate() {
             let query = simple_query(&format!("SET SERVER ROLE TO '{}'", role));
             assert_eq!(
-                qr.try_parse_command(query),
+                qr.try_execute_command(query),
                 Some((Command::SetServerRole, String::from(*role)))
             );
             assert_eq!(qr.role(), verify_roles[idx],);
@@ -459,7 +459,7 @@ mod test {
             // ShowServerRole
             let query = simple_query("SHOW SERVER ROLE");
             assert_eq!(
-                qr.try_parse_command(query),
+                qr.try_execute_command(query),
                 Some((Command::ShowServerRole, String::from(*role)))
             );
         }
@@ -471,7 +471,7 @@ mod test {
         let mut qr = QueryRouter::new(None, 5, false, false);
         let query = simple_query("SET SERVER ROLE TO 'auto'");
 
-        assert!(qr.try_parse_command(query) != None);
+        assert!(qr.try_execute_command(query) != None);
         assert!(qr.query_parser_enabled());
         assert_eq!(qr.role(), None);
 

--- a/tests/ruby/tests.rb
+++ b/tests/ruby/tests.rb
@@ -18,6 +18,13 @@ class TestTable < ActiveRecord::Base
   self.table_name = "test_table"
 end
 
+class TestSafeTable < ActiveRecord::Base
+  self.table_name = "test_safe_table"
+end
+
+class ShouldNeverHappenException < Exception
+end
+
 # # Create the table.
 class CreateTestTable < ActiveRecord::Migration[7.0]
   # Disable transasctions or things will fly out of order!
@@ -30,6 +37,7 @@ class CreateTestTable < ActiveRecord::Migration[7.0]
       # This will make this migration reversible!
       reversible do
         connection.execute "SET SHARD TO '#{x.to_i}'"
+        connection.execute "SET SERVER ROLE TO 'primary'"
       end
 
       # Always wrap the entire migration inside a transaction. If that's not possible,
@@ -47,28 +55,82 @@ class CreateTestTable < ActiveRecord::Migration[7.0]
   end
 end
 
-begin
-  CreateTestTable.migrate(:down)
-rescue Exception
-  puts "Tables don't exist yet"
-end
+class CreateSafeShardedTable < ActiveRecord::Migration[7.0]
+  # Disable transasctions or things will fly out of order!
+  disable_ddl_transaction!
 
-CreateTestTable.migrate(:up)
+  SHARDS = 3
 
-10.times do |x|
-  x += 1 # Postgres ids start at 1
-  r = TestTable.connection.execute "SET SHARDING KEY TO '#{x.to_i}'"
+  def up
+    SHARDS.times do |x|
+      # This will make this migration reversible!
+      connection.execute "SET SHARD TO '#{x.to_i}'"
+      connection.execute "SET SERVER ROLE TO 'primary'"
 
-  # Always wrap writes inside explicit transactions like these because ActiveRecord may fetch table info
-  # before actually issuing the `INSERT` statement. This ensures that that happens inside a transaction
-  # and the write goes to the correct shard.
-  TestTable.connection.transaction do
-    TestTable.create(id: x, name: "something_special_#{x.to_i}", description: "It's a surprise!")
+      connection.execute <<-SQL
+        CREATE TABLE test_safe_table (
+          id BIGINT PRIMARY KEY,
+          name VARCHAR,
+          description TEXT
+        ) PARTITION BY HASH (id);
+
+        CREATE TABLE test_safe_table_data PARTITION OF test_safe_table
+        FOR VALUES WITH (MODULUS #{SHARDS.to_i}, REMAINDER #{x.to_i});
+      SQL
+    end
+  end
+
+  def down
+    SHARDS.times do |x|
+      connection.execute "SET SHARD TO '#{x.to_i}'"
+      connection.execute "SET SERVER ROLE TO 'primary'"
+      connection.execute "DROP TABLE test_safe_table CASCADE"
+    end
   end
 end
 
-10.times do |x|
-  x += 1 # 0 confuses our sharding function
-  TestTable.connection.execute "SET SHARDING KEY TO '#{x.to_i}'"
-  puts TestTable.find_by_id(x).id
+20.times do
+  begin
+    CreateTestTable.migrate(:down)
+  rescue Exception
+    puts "Tables don't exist yet"
+  end
+
+  begin
+    CreateSafeShardedTable.migrate(:down)
+  rescue Exception
+    puts "Tables don't exist yet"
+  end
+
+  CreateTestTable.migrate(:up)
+  CreateSafeShardedTable.migrate(:up)
+
+  3.times do |x|
+    TestSafeTable.connection.execute "SET SHARD TO '#{x.to_i}'"
+    TestSafeTable.connection.execute "SET SERVER ROLE TO 'primary'"
+    TestSafeTable.connection.execute "TRUNCATE #{TestTable.table_name}"
+  end
+
+  10.times do |x|
+    x += 1 # Postgres ids start at 1
+    TestSafeTable.connection.execute "SET SHARDING KEY TO '#{x.to_i}'"
+    TestSafeTable.connection.execute "SET SERVER ROLE TO 'primary'"
+    TestSafeTable.create(id: x, name: "something_special_#{x.to_i}", description: "It's a surprise!")
+  end
+
+  10.times do |x|
+    x += 1 # 0 confuses our sharding function
+    TestSafeTable.connection.execute "SET SHARDING KEY TO '#{x.to_i}'"
+    TestSafeTable.connection.execute "SET SERVER ROLE TO 'replica'"
+    TestSafeTable.find_by_id(x).id
+  end
+end
+
+# Test wrong shard
+TestSafeTable.connection.execute "SET SHARD TO '1'"
+begin
+  TestSafeTable.create(id: 5, name: "test", description: "test description")
+  raise ShouldNeverHappenException("Uh oh")
+rescue ActiveRecord::StatementInvalid
+  puts "OK"
 end

--- a/tests/ruby/tests.rb
+++ b/tests/ruby/tests.rb
@@ -1,7 +1,8 @@
 require "active_record"
 
-ActiveRecord.verbose_query_logs = true
-ActiveRecord::Base.logger = Logger.new(STDOUT)
+# Uncomment these two to see all queries.
+# ActiveRecord.verbose_query_logs = true
+# ActiveRecord::Base.logger = Logger.new(STDOUT)
 
 ActiveRecord::Base.establish_connection(
   adapter: "postgresql",


### PR DESCRIPTION
### Features
1. Add `SHOW SHARD` and `SHOW SERVER ROLE` commands.
2. `SET SHARD`, `SET SERVER ROLE` and `SET SERVER KEY` last until they are set again, and not until the end of the transaction. This makes the state machine much easier to use and reason about.

### Changelog
1. Refactor QueryRouter some more to support many more commands if needed.
2. Documentation.