### PR TITLE
Can pass config path as argument

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -172,7 +172,7 @@ pub async fn parse(path: &str) -> Result<(), Error> {
     let mut file = match File::open(path).await {
         Ok(file) => file,
         Err(err) => {
-            error!("{:?}", err);
+            error!("Could not open '{}': {}", path, err.to_string());
             return Err(Error::BadConfig);
         }
     };
@@ -180,7 +180,7 @@ pub async fn parse(path: &str) -> Result<(), Error> {
     match file.read_to_string(&mut contents).await {
         Ok(_) => (),
         Err(err) => {
-            error!("{:?}", err);
+            error!("Could not read config file: {}", err.to_string());
             return Err(Error::BadConfig);
         }
     };
@@ -188,7 +188,7 @@ pub async fn parse(path: &str) -> Result<(), Error> {
     let config: Config = match toml::from_str(&contents) {
         Ok(config) => config,
         Err(err) => {
-            error!("{:?}", err);
+            error!("Could not parse config file: {}", err.to_string());
             return Err(Error::BadConfig);
         }
     };
@@ -199,6 +199,14 @@ pub async fn parse(path: &str) -> Result<(), Error> {
         // let's make sure they are unique in the config as well.
         let mut dup_check = HashSet::new();
         let mut primary_count = 0;
+
+        match shard.0.parse::<usize>() {
+            Ok(_) => (),
+            Err(_) => {
+                error!("Shard '{}' is not a valid number, shards must be numbered starting at 0", shard.0);
+                return Err(Error::BadConfig);
+            }
+        };
 
         if shard.1.servers.len() == 0 {
             error!("Shard {} has no servers configured", shard.0);

--- a/src/config.rs
+++ b/src/config.rs
@@ -203,7 +203,10 @@ pub async fn parse(path: &str) -> Result<(), Error> {
         match shard.0.parse::<usize>() {
             Ok(_) => (),
             Err(_) => {
-                error!("Shard '{}' is not a valid number, shards must be numbered starting at 0", shard.0);
+                error!(
+                    "Shard '{}' is not a valid number, shards must be numbered starting at 0",
+                    shard.0
+                );
                 return Err(Error::BadConfig);
             }
         };

--- a/src/main.rs
+++ b/src/main.rs
@@ -75,8 +75,16 @@ async fn main() {
         return;
     }
 
+    let args = std::env::args().collect::<Vec<String>>();
+
+    let config_file = if args.len() == 2 {
+        args[1].to_string()
+    } else {
+        String::from("pgcat.toml")
+    };
+
     // Prepare the config
-    match config::parse("pgcat.toml").await {
+    match config::parse(&config_file).await {
         Ok(_) => (),
         Err(err) => {
             error!("Config parse error: {:?}", err);


### PR DESCRIPTION
### Features
1. Pass config file path as argument to pgcat, e.g. `cargo run --release /etc/pgcat/pgcat.toml`.