### PR TITLE
Allow to set shard and set sharding key without quotes

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -229,8 +229,14 @@ impl Client {
                     }
                 }
 
-                Some((Command::SetShard, _)) | Some((Command::SetShardingKey, _)) => {
+                Some((Command::SetShard, _)) => {
                     custom_protocol_response_ok(&mut self.write, &format!("SET SHARD")).await?;
+                    continue;
+                }
+
+                Some((Command::SetShardingKey, _)) => {
+                    custom_protocol_response_ok(&mut self.write, &format!("SET SHARDING KEY"))
+                        .await?;
                     continue;
                 }
 

--- a/src/query_router.rs
+++ b/src/query_router.rs
@@ -11,11 +11,11 @@ use sqlparser::dialect::PostgreSqlDialect;
 use sqlparser::parser::Parser;
 
 const CUSTOM_SQL_REGEXES: [&str; 5] = [
-    r"(?i)SET SHARDING KEY TO '?([0-9]+)'? *",
-    r"(?i)SET SHARD TO '?([0-9]+)'? *",
-    r"(?i)SHOW SHARD",
-    r"(?i)SET SERVER ROLE TO '(PRIMARY|REPLICA|ANY|AUTO|DEFAULT)'",
-    r"(?i)SHOW SERVER ROLE",
+    r"(?i)^ *SET SHARDING KEY TO '?([0-9]+)'? *",
+    r"(?i)^ *SET SHARD TO '?([0-9]+)'? *",
+    r"(?i)^ *SHOW SHARD",
+    r"(?i)^ *SET SERVER ROLE TO '(PRIMARY|REPLICA|ANY|AUTO|DEFAULT)'",
+    r"(?i)^ *SHOW SERVER ROLE",
 ];
 
 #[derive(PartialEq, Debug)]

--- a/src/query_router.rs
+++ b/src/query_router.rs
@@ -470,7 +470,7 @@ mod test {
         let mut qr = QueryRouter::new();
 
         // SetShardingKey
-        let query = simple_query("SET SHARDING KEY TO '13'");
+        let query = simple_query("SET SHARDING KEY TO 13");
         assert_eq!(
             qr.try_execute_command(query),
             Some((Command::SetShardingKey, String::from("1")))


### PR DESCRIPTION
### Features
1. Allows no quotes syntax for `SET SHARDING KEY` and `SET SHARD`, e.g. `SET SHARDING KEY to 1234` instead of `'1234'`.
2. Faster regex because of `^` and `$` limits.
3. Answer `SET SHARDING KEY TO` with `SET SHARDING KEY` so it's not confused with `SET SHARD`.