### PR TITLE
Only set application_name if it's different

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -369,6 +369,7 @@ impl Client {
                             if server.in_transaction() {
                                 server.query("ROLLBACK").await?;
                                 server.query("DISCARD ALL").await?;
+                                server.set_name("pgcat").await?;
                             }
 
                             return Err(err);
@@ -440,6 +441,7 @@ impl Client {
                         if server.in_transaction() {
                             server.query("ROLLBACK").await?;
                             server.query("DISCARD ALL").await?;
+                            server.set_name("pgcat").await?;
                         }
 
                         self.release();

--- a/src/server.rs
+++ b/src/server.rs
@@ -213,7 +213,7 @@ impl Server {
 
                     let (read, write) = stream.into_split();
 
-                    return Ok(Server {
+                    let mut server = Server {
                         address: address.clone(),
                         read: BufReader::new(read),
                         write: write,
@@ -227,8 +227,12 @@ impl Server {
                         client_server_map: client_server_map,
                         connected_at: chrono::offset::Utc::now().naive_utc(),
                         stats: stats,
-                        application_name: String::from("pgcat"),
-                    });
+                        application_name: String::new(),
+                    };
+
+                    server.set_name("pgcat").await?;
+
+                    return Ok(server);
                 }
 
                 // We have an unexpected message from the server during this exchange.

--- a/src/server.rs
+++ b/src/server.rs
@@ -54,6 +54,9 @@ pub struct Server {
 
     /// Reports various metrics, e.g. data sent & received.
     stats: Reporter,
+
+    /// Application name using the server at the moment.
+    application_name: String,
 }
 
 impl Server {
@@ -224,6 +227,7 @@ impl Server {
                         client_server_map: client_server_map,
                         connected_at: chrono::offset::Utc::now().naive_utc(),
                         stats: stats,
+                        application_name: String::from("pgcat"),
                     });
                 }
 
@@ -448,9 +452,14 @@ impl Server {
     /// A shorthand for `SET application_name = $1`.
     #[allow(dead_code)]
     pub async fn set_name(&mut self, name: &str) -> Result<(), Error> {
-        Ok(self
-            .query(&format!("SET application_name = '{}'", name))
-            .await?)
+        if self.application_name != name {
+            self.application_name = name.to_string();
+            Ok(self
+                .query(&format!("SET application_name = '{}'", name))
+                .await?)
+        } else {
+            Ok(())
+        }
     }
 
     /// Get the servers address.


### PR DESCRIPTION
Optimization for #73 in support of fixing #72 .

Issue `SET application_name = ...` only if the `application_name` changed, reducing query count substantially for most use cases.
If the client disconnects mid-transaction, return the server to the pool with the default `application_name` set ("pgcat").