### PR TITLE
Client md5 auth and clean up scram

### DIFF
--- a/.circleci/run_tests.sh
+++ b/.circleci/run_tests.sh
@@ -100,7 +100,7 @@ sed -i 's/pool_mode = "transaction"/pool_mode = "session"/' pgcat.toml
 kill -SIGHUP $(pgrep pgcat)
 
 # Prepared statements that will only work in session mode
-pgbench -h 127.0.0.1 -p 6432 -t 500 -c 2 --protocol prepared
+pgbench -U sharding_user -h 127.0.0.1 -p 6432 -t 500 -c 2 --protocol prepared
 
 # Attempt clean shut down
 killall pgcat -s SIGINT

--- a/.circleci/run_tests.sh
+++ b/.circleci/run_tests.sh
@@ -13,9 +13,13 @@ function start_pgcat() {
 
 # Setup the database with shards and user
 PGPASSWORD=postgres psql -e -h 127.0.0.1 -p 5432 -U postgres -f tests/sharding/query_routing_setup.sql
-PGPASSWORD=sharding_user pgbench -h 127.0.0.1 -U sharding_user shard0 -i
-PGPASSWORD=sharding_user pgbench -h 127.0.0.1 -U sharding_user shard1 -i
-PGPASSWORD=sharding_user pgbench -h 127.0.0.1 -U sharding_user shard2 -i
+
+#
+export PGPASSWORD=sharding_user
+
+pgbench -h 127.0.0.1 -U sharding_user shard0 -i
+pgbench -h 127.0.0.1 -U sharding_user shard1 -i
+pgbench -h 127.0.0.1 -U sharding_user shard2 -i
 
 # Install Toxiproxy to simulate a downed/slow database
 wget -O toxiproxy-2.1.4.deb https://github.com/Shopify/toxiproxy/releases/download/v2.1.4/toxiproxy_2.1.4_amd64.deb

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -368,7 +368,7 @@ dependencies = [
 
 [[package]]
 name = "pgcat"
-version = "0.1.0-beta2"
+version = "0.2.0-beta1"
 dependencies = [
  "arc-swap",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgcat"
-version = "0.2.0-beta1"
+version = "0.2.1-beta1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,5 +7,5 @@ FROM debian:buster-slim
 COPY --from=builder /app/target/release/pgcat /usr/bin/pgcat
 COPY --from=builder /app/pgcat.toml /etc/pgcat/pgcat.toml
 WORKDIR /etc/pgcat
-ENV RUST_LOG=info
+ENV RUST_LOG=trace
 CMD ["pgcat"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,5 +7,5 @@ FROM debian:buster-slim
 COPY --from=builder /app/target/release/pgcat /usr/bin/pgcat
 COPY --from=builder /app/pgcat.toml /etc/pgcat/pgcat.toml
 WORKDIR /etc/pgcat
-ENV RUST_LOG=trace
+ENV RUST_LOG=info
 CMD ["pgcat"]

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -9,4 +9,5 @@ pub enum Error {
     ServerError,
     BadConfig,
     AllServersDown,
+    ClientError,
 }


### PR DESCRIPTION
- Cleaned up `SCRAM-SHA-256` auth (made it safer, no panics).
- Added client MD5 auth requirement. SASL to-do.