### PR TITLE
Live reloading entire config and bug fixes

### DIFF
--- a/.circleci/pgcat.toml
+++ b/.circleci/pgcat.toml
@@ -87,7 +87,7 @@ default_role = "any"
 # every incoming query to determine if it's a read or a write.
 # If it's a read query, we'll direct it to a replica. Otherwise, if it's a write,
 # we'll direct it to the primary.
-query_parser_enabled = false
+query_parser_enabled = true
 
 # If the query parser is enabled and this setting is enabled, the primary will be part of the pool of databases used for
 # load balancing of read queries. Otherwise, the primary will only be used for write

--- a/.circleci/run_tests.sh
+++ b/.circleci/run_tests.sh
@@ -42,7 +42,7 @@ pgbench -U sharding_user -h 127.0.0.1 -p 6432 -t 500 -c 2 --protocol extended
 psql -U sharding_user -h 127.0.0.1 -p 6432 -c 'COPY (SELECT * FROM pgbench_accounts LIMIT 15) TO STDOUT;' > /dev/null
 
 # Query cancellation test
-(psql -U sharding_user -h 127.0.0.1 -p 6432 -c 'SELECT pg_sleep(5)' || true) &
+(psql -U sharding_user -h 127.0.0.1 -p 6432 -c 'SELECT pg_sleep(50)' || true) &
 killall psql -s SIGINT
 
 # Sharding insert

--- a/.circleci/run_tests.sh
+++ b/.circleci/run_tests.sh
@@ -102,7 +102,7 @@ toxiproxy-cli toxic remove --toxicName latency_downstream postgres_replica
 start_pgcat "info"
 
 # Test session mode (and config reload)
-sed -i 's/pool_mode = "transaction"/pool_mode = "session"/' ./circleci/pgcat.toml
+sed -i 's/pool_mode = "transaction"/pool_mode = "session"/' .circleci/pgcat.toml
 
 # Reload config test
 kill -SIGHUP $(pgrep pgcat)

--- a/.circleci/run_tests.sh
+++ b/.circleci/run_tests.sh
@@ -43,12 +43,14 @@ psql -U sharding_user -h 127.0.0.1 -p 6432 -c 'COPY (SELECT * FROM pgbench_accou
 
 # Query cancellation test
 (psql -U sharding_user -h 127.0.0.1 -p 6432 -c 'SELECT pg_sleep(50)' || true) &
+sleep 1
 killall psql -s SIGINT
 
 # Reload pool (closing unused server connections)
 psql -U sharding_user -h 127.0.0.1 -p 6432 -d pgbouncer -c 'RELOAD'
 
 (psql -U sharding_user -h 127.0.0.1 -p 6432 -c 'SELECT pg_sleep(50)' || true) &
+sleep 1
 killall psql -s SIGINT
 
 # Sharding insert

--- a/.circleci/run_tests.sh
+++ b/.circleci/run_tests.sh
@@ -45,6 +45,12 @@ psql -U sharding_user -h 127.0.0.1 -p 6432 -c 'COPY (SELECT * FROM pgbench_accou
 (psql -U sharding_user -h 127.0.0.1 -p 6432 -c 'SELECT pg_sleep(50)' || true) &
 killall psql -s SIGINT
 
+# Reload pool (closing unused server connections)
+psql -U sharding_user -h 127.0.0.1 -p 6432 -c 'RELOAD'
+
+(psql -U sharding_user -h 127.0.0.1 -p 6432 -c 'SELECT pg_sleep(50)' || true) &
+killall psql -s SIGINT
+
 # Sharding insert
 psql -U sharding_user -e -h 127.0.0.1 -p 6432 -f tests/sharding/query_routing_test_insert.sql
 

--- a/.circleci/run_tests.sh
+++ b/.circleci/run_tests.sh
@@ -46,7 +46,7 @@ psql -U sharding_user -h 127.0.0.1 -p 6432 -c 'COPY (SELECT * FROM pgbench_accou
 killall psql -s SIGINT
 
 # Reload pool (closing unused server connections)
-psql -U sharding_user -h 127.0.0.1 -p 6432 -c 'RELOAD'
+psql -U sharding_user -h 127.0.0.1 -p 6432 -d pgbouncer -c 'RELOAD'
 
 (psql -U sharding_user -h 127.0.0.1 -p 6432 -c 'SELECT pg_sleep(50)' || true) &
 killall psql -s SIGINT

--- a/.circleci/run_tests.sh
+++ b/.circleci/run_tests.sh
@@ -102,7 +102,7 @@ toxiproxy-cli toxic remove --toxicName latency_downstream postgres_replica
 start_pgcat "info"
 
 # Test session mode (and config reload)
-sed -i 's/pool_mode = "transaction"/pool_mode = "session"/' pgcat.toml
+sed -i 's/pool_mode = "transaction"/pool_mode = "session"/' ./circleci/pgcat.toml
 
 # Reload config test
 kill -SIGHUP $(pgrep pgcat)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -368,7 +368,7 @@ dependencies = [
 
 [[package]]
 name = "pgcat"
-version = "0.2.0-beta1"
+version = "0.4.0-beta1"
 dependencies = [
  "arc-swap",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgcat"
-version = "0.2.1-beta1"
+version = "0.4.0-beta1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/pgcat.toml
+++ b/pgcat.toml
@@ -61,14 +61,14 @@ servers = [
 ]
 database = "shard1"
 
-# [shards.2]
-# # [ host, port, role ]
-# servers = [
-#     [ "127.0.0.1", 5432, "primary" ],
-#     [ "localhost", 5432, "replica" ],
-#     # [ "127.0.1.1", 5432, "replica" ],
-# ]
-# database = "shard2"
+[shards.2]
+# [ host, port, role ]
+servers = [
+    [ "127.0.0.1", 5432, "primary" ],
+    [ "localhost", 5432, "replica" ],
+    # [ "127.0.1.1", 5432, "replica" ],
+]
+database = "shard2"
 
 
 # Settings for our query routing layer.

--- a/pgcat.toml
+++ b/pgcat.toml
@@ -87,7 +87,7 @@ default_role = "any"
 # every incoming query to determine if it's a read or a write.
 # If it's a read query, we'll direct it to a replica. Otherwise, if it's a write,
 # we'll direct it to the primary.
-query_parser_enabled = false
+query_parser_enabled = true
 
 # If the query parser is enabled and this setting is enabled, the primary will be part of the pool of databases used for
 # load balancing of read queries. Otherwise, the primary will only be used for write

--- a/pgcat.toml
+++ b/pgcat.toml
@@ -61,14 +61,14 @@ servers = [
 ]
 database = "shard1"
 
-[shards.2]
-# [ host, port, role ]
-servers = [
-    [ "127.0.0.1", 5432, "primary" ],
-    [ "localhost", 5432, "replica" ],
-    # [ "127.0.1.1", 5432, "replica" ],
-]
-database = "shard2"
+# [shards.2]
+# # [ host, port, role ]
+# servers = [
+#     [ "127.0.0.1", 5432, "primary" ],
+#     [ "localhost", 5432, "replica" ],
+#     # [ "127.0.1.1", 5432, "replica" ],
+# ]
+# database = "shard2"
 
 
 # Settings for our query routing layer.

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -8,9 +8,9 @@ use crate::config::{get_config, parse};
 use crate::errors::Error;
 use crate::messages::*;
 use crate::pool::ConnectionPool;
+use crate::stats::get_reporter;
 use crate::stats::get_stats;
 use crate::ClientServerMap;
-use crate::REPORTER;
 
 /// Handle admin client.
 pub async fn handle_admin(
@@ -281,7 +281,7 @@ async fn reload(
     parse(&path).await?;
 
     let config = get_config();
-    ConnectionPool::from_config(client_server_map, (*(*REPORTER.load())).clone()).await;
+    ConnectionPool::from_config(client_server_map, get_reporter()).await;
 
     config.show();
 

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -269,7 +269,7 @@ async fn reload(
 ) -> Result<(), Error> {
     info!("Reloading config");
 
-    reload_config(client_server_map).await;
+    reload_config(client_server_map).await?;
 
     get_config().show();
 

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -146,10 +146,7 @@ async fn show_version(stream: &mut OwnedWriteHalf) -> Result<(), Error> {
 /// Show utilization of connection pools for each shard and replicas.
 async fn show_pools(stream: &mut OwnedWriteHalf, pool: &ConnectionPool) -> Result<(), Error> {
     let stats = get_stats();
-    let config = {
-        let guard = get_config();
-        &*guard.clone()
-    };
+    let config = get_config();
 
     let columns = vec![
         ("database", DataType::Text),
@@ -202,9 +199,7 @@ async fn show_pools(stream: &mut OwnedWriteHalf, pool: &ConnectionPool) -> Resul
 
 /// Show shards and replicas.
 async fn show_databases(stream: &mut OwnedWriteHalf, pool: &ConnectionPool) -> Result<(), Error> {
-    let guard = get_config();
-    let config = &*guard.clone();
-    drop(guard);
+    let config = get_config();
 
     // Columns
     let columns = vec![
@@ -276,7 +271,7 @@ async fn reload(
     info!("Reloading config");
 
     let config = get_config();
-    let path = config.path.clone().unwrap();
+    let path = config.path.clone();
 
     parse(&path).await?;
 
@@ -299,10 +294,8 @@ async fn reload(
 
 /// Shows current configuration.
 async fn show_config(stream: &mut OwnedWriteHalf) -> Result<(), Error> {
-    let guard = get_config();
-    let config = &*guard.clone();
+    let config = &get_config();
     let config: HashMap<String, String> = config.into();
-    drop(guard);
 
     // Configs that cannot be changed without restarting.
     let immutables = ["host", "port", "connect_timeout"];

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -4,11 +4,10 @@ use log::{info, trace};
 use std::collections::HashMap;
 use tokio::net::tcp::OwnedWriteHalf;
 
-use crate::config::{get_config, parse};
+use crate::config::{get_config, reload_config};
 use crate::errors::Error;
 use crate::messages::*;
 use crate::pool::ConnectionPool;
-use crate::stats::get_reporter;
 use crate::stats::get_stats;
 use crate::ClientServerMap;
 
@@ -270,15 +269,9 @@ async fn reload(
 ) -> Result<(), Error> {
     info!("Reloading config");
 
-    let config = get_config();
-    let path = config.path.clone();
+    reload_config(client_server_map).await;
 
-    parse(&path).await?;
-
-    let config = get_config();
-    ConnectionPool::from_config(client_server_map, get_reporter()).await;
-
-    config.show();
+    get_config().show();
 
     let mut res = BytesMut::new();
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -13,7 +13,7 @@ use crate::config::get_config;
 use crate::constants::*;
 use crate::errors::Error;
 use crate::messages::*;
-use crate::pool::{ClientServerMap};
+use crate::pool::ClientServerMap;
 use crate::query_router::{Command, QueryRouter};
 use crate::server::Server;
 use crate::stats::Reporter;

--- a/src/client.rs
+++ b/src/client.rs
@@ -261,7 +261,7 @@ impl Client {
         // We expect the client to either start a transaction with regular queries
         // or issue commands for our sharding and server selection protocol.
         loop {
-            trace!("Client idle, waiting for message");
+            trace!("Client idle, waiting for message, transaction mode: {}", self.transaction_mode);
 
             // Read a complete message from the client, which normally would be
             // either a `Q` (query) or `P` (prepare, extended protocol).

--- a/src/client.rs
+++ b/src/client.rs
@@ -261,7 +261,10 @@ impl Client {
         // We expect the client to either start a transaction with regular queries
         // or issue commands for our sharding and server selection protocol.
         loop {
-            trace!("Client idle, waiting for message, transaction mode: {}", self.transaction_mode);
+            trace!(
+                "Client idle, waiting for message, transaction mode: {}",
+                self.transaction_mode
+            );
 
             // Read a complete message from the client, which normally would be
             // either a `Q` (query) or `P` (prepare, extended protocol).

--- a/src/client.rs
+++ b/src/client.rs
@@ -297,7 +297,7 @@ impl Client {
             let current_shard = query_router.shard();
 
             // Handle all custom protocol commands, if any.
-            match query_router.try_execute_command(message.clone(), &pool) {
+            match query_router.try_execute_command(message.clone()) {
                 // Normal query, not a custom command.
                 None => (),
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -323,6 +323,11 @@ impl Client {
                     continue;
                 }
 
+                Some((Command::TogglePrimaryReads, _)) => {
+                    custom_protocol_response_ok(&mut self.write, "SET PRIMARY READS").await?;
+                    continue;
+                }
+
                 // SET SHARDING KEY TO
                 Some((Command::SetShardingKey, _)) => {
                     custom_protocol_response_ok(&mut self.write, "SET SHARDING KEY").await?;

--- a/src/config.rs
+++ b/src/config.rs
@@ -375,14 +375,14 @@ pub async fn parse(path: &str) -> Result<(), Error> {
     Ok(())
 }
 
-pub async fn reload_config(client_server_map: ClientServerMap) {
+pub async fn reload_config(client_server_map: ClientServerMap) -> Result<(), Error> {
     let old_config = get_config();
 
     match parse(&old_config.path).await {
         Ok(()) => (),
         Err(err) => {
             error!("Config reload error: {:?}", err);
-            return;
+            return Err(Error::BadConfig);
         }
     };
 
@@ -390,7 +390,9 @@ pub async fn reload_config(client_server_map: ClientServerMap) {
 
     if old_config.shards != new_config.shards {
         info!("Sharding configuration changed, re-creating server pools");
-        ConnectionPool::from_config(client_server_map, get_reporter()).await;
+        ConnectionPool::from_config(client_server_map, get_reporter()).await
+    } else {
+        Ok(())
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -10,7 +10,6 @@ use tokio::io::AsyncReadExt;
 use toml;
 
 use crate::errors::Error;
-use crate::stats::get_reporter;
 use crate::{ClientServerMap, ConnectionPool};
 
 /// Globally available configuration.
@@ -390,7 +389,7 @@ pub async fn reload_config(client_server_map: ClientServerMap) -> Result<(), Err
 
     if old_config.shards != new_config.shards {
         info!("Sharding configuration changed, re-creating server pools");
-        ConnectionPool::from_config(client_server_map, get_reporter()).await
+        ConnectionPool::from_config(client_server_map).await
     } else {
         Ok(())
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -237,6 +237,8 @@ impl Config {
         );
         info!("Connection timeout: {}ms", self.general.connect_timeout);
         info!("Sharding function: {}", self.query_router.sharding_function);
+        info!("Primary reads: {}", self.query_router.primary_reads_enabled);
+        info!("Query router: {}", self.query_router.query_parser_enabled);
         info!("Number of shards: {}", self.shards.len());
     }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -10,6 +10,4 @@ pub enum Error {
     BadConfig,
     AllServersDown,
     ClientError,
-    QueryRouterError,
-    BadShard,
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -10,4 +10,6 @@ pub enum Error {
     BadConfig,
     AllServersDown,
     ClientError,
+    QueryRouterError,
+    BadShard,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -138,6 +138,8 @@ async fn main() {
 
     info!("Waiting for clients");
 
+    drop(pool);
+
     // Client connection loop.
     tokio::task::spawn(async move {
         loop {

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,7 +34,7 @@ extern crate sqlparser;
 extern crate tokio;
 extern crate toml;
 
-use log::{error, info};
+use log::{debug, error, info};
 use parking_lot::Mutex;
 use tokio::net::TcpListener;
 use tokio::{

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Lev Kokotov <lev@levthe.dev>
+// Copyright (c) 2022 Lev Kokotov <hi@levthe.dev>
 
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the
@@ -177,7 +177,7 @@ async fn main() {
                     }
 
                     Err(err) => {
-                        error!("Client failed to login: {:?}", err);
+                        debug!("Client failed to login: {:?}", err);
                     }
                 };
             });

--- a/src/main.rs
+++ b/src/main.rs
@@ -60,8 +60,8 @@ mod sharding;
 mod stats;
 
 use config::get_config;
-use pool::{ClientServerMap, ConnectionPool, POOL};
-use stats::{Collector, Reporter, REPORTER};
+use pool::{ClientServerMap, ConnectionPool};
+use stats::{get_reporter, Collector, Reporter, REPORTER};
 
 #[tokio::main(worker_threads = 4)]
 async fn main() {
@@ -200,7 +200,7 @@ async fn main() {
             info!("Reloading config");
             match config::parse("pgcat.toml").await {
                 Ok(_) => {
-                    let reporter = (*(*REPORTER.load())).clone();
+                    let reporter = get_reporter();
                     let config = get_config();
                     ConnectionPool::from_config(reload_client_server_map.clone(), reporter).await;
                     config.show();

--- a/src/main.rs
+++ b/src/main.rs
@@ -112,7 +112,7 @@ async fn main() {
     REPORTER.store(Arc::new(Reporter::new(tx.clone())));
 
     // Connection pool that allows to query all shards and replicas.
-    match ConnectionPool::from_config(client_server_map.clone(), Reporter::new(tx.clone())).await {
+    match ConnectionPool::from_config(client_server_map.clone()).await {
         Ok(_) => (),
         Err(err) => {
             error!("Pool error: {:?}", err);

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -479,3 +479,8 @@ impl ManageConnection for ServerPool {
         conn.is_bad()
     }
 }
+
+/// Get the connection pool
+pub fn get_pool() -> ConnectionPool {
+    (*(*POOL.load())).clone()
+}

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -175,11 +175,9 @@ impl ConnectionPool {
                     }
                 };
 
-                let mut proxy = connection.0;
+                let proxy = connection.0;
                 let address = connection.1;
-                let server = &mut *proxy;
-                round_robin += 1;
-
+                let server = &*proxy;
                 let server_info = server.server_info();
 
                 stats.client_disconnecting(fake_process_id, address.id);
@@ -195,6 +193,7 @@ impl ConnectionPool {
                 }
 
                 server_infos.push(server_info);
+                round_robin += 1;
             }
         }
 
@@ -259,6 +258,7 @@ impl ConnectionPool {
 
             allowed_attempts -= 1;
 
+            // Don't attempt to connect to banned servers.
             if self.is_banned(address, shard, role) {
                 continue;
             }

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -213,7 +213,7 @@ impl ConnectionPool {
 
         while allowed_attempts > 0 {
             // Round-robin replicas.
-            // self.round_robin += 1;
+            self.round_robin += 1;
 
             let index = self.round_robin % addresses.len();
             let address = &addresses[index];

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -29,6 +29,7 @@ pub struct ConnectionPool {
     addresses: Vec<Vec<Address>>,
     banlist: BanList,
     stats: Reporter,
+    server_info: BytesMut,
 }
 
 impl ConnectionPool {
@@ -115,6 +116,7 @@ impl ConnectionPool {
             addresses: addresses,
             banlist: Arc::new(RwLock::new(banlist)),
             stats: stats,
+            server_info: BytesMut::new(),
         };
 
         POOL.store(Arc::new(pool.clone()));
@@ -175,7 +177,8 @@ impl ConnectionPool {
             return Err(Error::AllServersDown);
         }
 
-        Ok(server_infos[0].clone())
+        self.server_info = server_infos[0].clone();
+        Ok(self.server_info.clone())
     }
 
     /// Get a connection from the pool.
@@ -399,6 +402,10 @@ impl ConnectionPool {
     /// Get the address information for a shard server.
     pub fn address(&self, shard: usize, server: usize) -> &Address {
         &self.addresses[shard][server]
+    }
+
+    pub fn server_info(&self) -> BytesMut {
+        self.server_info.clone()
     }
 }
 

--- a/src/query_router.rs
+++ b/src/query_router.rs
@@ -355,6 +355,12 @@ impl QueryRouter {
     pub fn set_shard(&mut self, shard: usize) {
         self.active_shard = Some(shard);
     }
+
+    /// Should we attempt to parse queries?
+    #[allow(dead_code)]
+    pub fn query_parser_enabled(&self) -> bool {
+        self.query_parser_enabled
+    }
 }
 
 #[cfg(test)]

--- a/src/query_router.rs
+++ b/src/query_router.rs
@@ -355,11 +355,6 @@ impl QueryRouter {
     pub fn set_shard(&mut self, shard: usize) {
         self.active_shard = Some(shard);
     }
-
-    /// Should we attempt to parse queries?
-    pub fn query_parser_enabled(&self) -> bool {
-        self.query_parser_enabled
-    }
 }
 
 #[cfg(test)]

--- a/src/query_router.rs
+++ b/src/query_router.rs
@@ -134,7 +134,7 @@ impl QueryRouter {
             return None;
         }
 
-        let config = get_config().clone();
+        let config = get_config();
 
         let sharding_function = match config.query_router.sharding_function.as_ref() {
             "pg_bigint_hash" => ShardingFunction::PgBigintHash,

--- a/src/query_router.rs
+++ b/src/query_router.rs
@@ -621,6 +621,6 @@ mod test {
         assert!(qr.query_parser_enabled());
         let query = simple_query("SET SERVER ROLE TO 'default'");
         assert!(qr.try_execute_command(query) != None);
-        assert!(!qr.query_parser_enabled());
+        assert!(qr.query_parser_enabled());
     }
 }

--- a/src/query_router.rs
+++ b/src/query_router.rs
@@ -131,6 +131,7 @@ impl QueryRouter {
                 debug!("Inferring role");
                 self.infer_role(buf.clone());
             }
+            return None;
         }
 
         let config = get_config().clone();

--- a/src/query_router.rs
+++ b/src/query_router.rs
@@ -330,6 +330,10 @@ impl QueryRouter {
         }
     }
 
+    pub fn set_shard(&mut self, shard: usize) {
+        self.active_shard = Some(shard);
+    }
+
     /// Reset the router back to defaults.
     /// This must be called at the end of every transaction in transaction mode.
     pub fn _reset(&mut self) {

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -1,9 +1,13 @@
+use arc_swap::ArcSwap;
 /// Statistics and reporting.
 use log::info;
 use once_cell::sync::Lazy;
 use parking_lot::Mutex;
 use std::collections::HashMap;
-use tokio::sync::mpsc::{Receiver, Sender};
+use tokio::sync::mpsc::{channel, Receiver, Sender};
+
+pub static REPORTER: Lazy<ArcSwap<Reporter>> =
+    Lazy::new(|| ArcSwap::from_pointee(Reporter::default()));
 
 /// Latest stats updated every second; used in SHOW STATS and other admin commands.
 static LATEST_STATS: Lazy<Mutex<HashMap<usize, HashMap<String, i64>>>> =
@@ -58,6 +62,13 @@ pub struct Event {
 #[derive(Clone, Debug)]
 pub struct Reporter {
     tx: Sender<Event>,
+}
+
+impl Default for Reporter {
+    fn default() -> Reporter {
+        let (tx, _rx) = channel(5);
+        Reporter { tx }
+    }
 }
 
 impl Reporter {

--- a/tests/pgbench/simple.sql
+++ b/tests/pgbench/simple.sql
@@ -12,6 +12,8 @@
 
 SET SHARD TO :shard;
 
+SET SERVER ROLE TO 'auto';
+
 BEGIN;
 
 UPDATE pgbench_accounts SET abalance = abalance + :delta WHERE aid = :aid;
@@ -26,3 +28,12 @@ INSERT INTO pgbench_history (tid, bid, aid, delta, mtime) VALUES (:tid, :bid, :a
 
 END;
 
+SET SHARDING KEY TO :aid;
+
+-- Read load balancing
+SELECT abalance FROM pgbench_accounts WHERE aid = :aid;
+
+SET SERVER ROLE TO 'replica';
+
+-- Read load balancing
+SELECT abalance FROM pgbench_accounts WHERE aid = :aid;

--- a/tests/sharding/query_routing_test_primary_replica.sql
+++ b/tests/sharding/query_routing_test_primary_replica.sql
@@ -151,3 +151,12 @@ SELECT 1;
 set server role to 'replica';
 SeT SeRver Role TO 'PrImARY';
 select 1;
+
+SET PRIMARY READS TO 'on';
+SELECT 1;
+
+SET PRIMARY READS TO 'off';
+SELECT 1;
+
+SET PRIMARY READS TO 'default';
+SELECT 1;


### PR DESCRIPTION
- Support reloading the entire config (including sharding logic) without restart.
- Fix bug incorrectly handing error reporting when the shard is set incorrectly via `SET SHARD TO` command. Thank you @DeoLeung for the original report in #80.
- Fix `total_received` and `avg_recv` admin database statistics.
- Enabling the query parser by default.
- More tests.