### PR TITLE
Allow reader/writer endpoints for pools

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -29,7 +29,7 @@ enum ClientConnectionType {
 pub enum ClientRoutingMode {
     Default,
     Reader,
-    Writer
+    Writer,
 }
 
 /// The client state. One of these is created per client.
@@ -81,7 +81,7 @@ pub struct Client<S, T> {
 
     target_pool: ConnectionPool,
 
-    routing_mode: ClientRoutingMode
+    routing_mode: ClientRoutingMode,
 }
 
 /// Client entrypoint.
@@ -278,25 +278,31 @@ where
             Some(db) => db,
             None => return Err(Error::ClientError),
         };
-        let database_name_parts  = database_param.split("/").collect::<Vec<&str>>();
+        let database_name_parts = database_param.split("/").collect::<Vec<&str>>();
         let (database_name, routing_mode) = match database_name_parts.len() {
-            1 => (database_name_parts[0].to_string(), ClientRoutingMode::Default),
+            1 => (
+                database_name_parts[0].to_string(),
+                ClientRoutingMode::Default,
+            ),
             2 => match database_name_parts[1] {
                 "reader" => {
                     info!("Client connected in force reader mode");
-                    (database_name_parts[0].to_string(), ClientRoutingMode::Reader)
-                },
+                    (
+                        database_name_parts[0].to_string(),
+                        ClientRoutingMode::Reader,
+                    )
+                }
                 "writer" => {
                     info!("Client connected in force writer mode");
-                    (database_name_parts[0].to_string(), ClientRoutingMode::Writer)
-                },
+                    (
+                        database_name_parts[0].to_string(),
+                        ClientRoutingMode::Writer,
+                    )
+                }
                 _ => {
                     error_response(
                         &mut write,
-                        &format!(
-                            "Invalid database mode {}",
-                            database_name_parts[1]
-                        ),
+                        &format!("Invalid database mode {}", database_name_parts[1]),
                     )
                     .await?;
                     return Err(Error::ClientError);
@@ -305,10 +311,7 @@ where
             _ => {
                 error_response(
                     &mut write,
-                    &format!(
-                        "Invalid database name {}",
-                        database_param
-                    ),
+                    &format!("Invalid database name {}", database_param),
                 )
                 .await?;
                 return Err(Error::ClientError);
@@ -495,7 +498,8 @@ where
 
         // The query router determines where the query is going to go,
         // e.g. primary, replica, which shard.
-        let mut query_router = QueryRouter::new(self.target_pool.clone(), self.routing_mode.clone());
+        let mut query_router =
+            QueryRouter::new(self.target_pool.clone(), self.routing_mode.clone());
 
         let mut round_robin = 0;
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -25,6 +25,13 @@ enum ClientConnectionType {
     CancelQuery,
 }
 
+#[derive(Clone, Copy, Debug)]
+pub enum ClientRoutingMode {
+    Default,
+    Reader,
+    Writer
+}
+
 /// The client state. One of these is created per client.
 pub struct Client<S, T> {
     /// The reads are buffered (8K by default).
@@ -73,6 +80,8 @@ pub struct Client<S, T> {
     last_server_id: Option<i32>,
 
     target_pool: ConnectionPool,
+
+    routing_mode: ClientRoutingMode
 }
 
 /// Client entrypoint.
@@ -264,9 +273,46 @@ where
 
         trace!("Got StartupMessage");
         let parameters = parse_startup(bytes.clone())?;
-        let database = match parameters.get("database") {
+
+        let database_param = match parameters.get("database") {
             Some(db) => db,
             None => return Err(Error::ClientError),
+        };
+        let database_name_parts  = database_param.split("/").collect::<Vec<&str>>();
+        let (database_name, routing_mode) = match database_name_parts.len() {
+            1 => (database_name_parts[0].to_string(), ClientRoutingMode::Default),
+            2 => match database_name_parts[1] {
+                "reader" => {
+                    info!("Client connected in force reader mode");
+                    (database_name_parts[0].to_string(), ClientRoutingMode::Reader)
+                },
+                "writer" => {
+                    info!("Client connected in force writer mode");
+                    (database_name_parts[0].to_string(), ClientRoutingMode::Writer)
+                },
+                _ => {
+                    error_response(
+                        &mut write,
+                        &format!(
+                            "Invalid database mode {}",
+                            database_name_parts[1]
+                        ),
+                    )
+                    .await?;
+                    return Err(Error::ClientError);
+                }
+            },
+            _ => {
+                error_response(
+                    &mut write,
+                    &format!(
+                        "Invalid database name {}",
+                        database_param
+                    ),
+                )
+                .await?;
+                return Err(Error::ClientError);
+            }
         };
 
         let user = match parameters.get("user") {
@@ -276,7 +322,7 @@ where
 
         let admin = ["pgcat", "pgbouncer"]
             .iter()
-            .filter(|db| *db == &database)
+            .filter(|db| *db == &database_name)
             .count()
             == 1;
 
@@ -326,14 +372,14 @@ where
                 return Err(Error::ClientError);
             }
         } else {
-            target_pool = match get_pool(database.clone(), user.clone()) {
+            target_pool = match get_pool(database_name.clone(), user.clone()) {
                 Some(pool) => pool,
                 None => {
                     error_response(
                         &mut write,
                         &format!(
                             "No pool configured for database: {:?}, user: {:?}",
-                            database, user
+                            database_name, user
                         ),
                     )
                     .await?;
@@ -372,6 +418,7 @@ where
             buffer: BytesMut::with_capacity(8196),
             cancel_mode: false,
             transaction_mode: transaction_mode,
+            routing_mode: routing_mode,
             process_id: process_id,
             secret_key: secret_key,
             client_server_map: client_server_map,
@@ -401,6 +448,7 @@ where
             buffer: BytesMut::with_capacity(8196),
             cancel_mode: true,
             transaction_mode: false,
+            routing_mode: ClientRoutingMode::Default,
             process_id: process_id,
             secret_key: secret_key,
             client_server_map: client_server_map,
@@ -447,7 +495,8 @@ where
 
         // The query router determines where the query is going to go,
         // e.g. primary, replica, which shard.
-        let mut query_router = QueryRouter::new(self.target_pool.clone());
+        let mut query_router = QueryRouter::new(self.target_pool.clone(), self.routing_mode.clone());
+
         let mut round_robin = 0;
 
         // Our custom protocol loop.

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -71,7 +71,6 @@ pub struct ConnectionPool {
     /// on pool creation and save the K messages here.
     server_info: BytesMut,
 
-
     pub settings: PoolSettings,
 }
 

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -71,6 +71,7 @@ pub struct ConnectionPool {
     /// on pool creation and save the K messages here.
     server_info: BytesMut,
 
+
     pub settings: PoolSettings,
 }
 

--- a/src/query_router.rs
+++ b/src/query_router.rs
@@ -58,7 +58,7 @@ pub struct QueryRouter {
 
     pool_settings: PoolSettings,
 
-    client_routing_mode: ClientRoutingMode
+    client_routing_mode: ClientRoutingMode,
 }
 
 impl QueryRouter {
@@ -101,7 +101,7 @@ impl QueryRouter {
             query_parser_enabled: target_pool.settings.query_parser_enabled,
             primary_reads_enabled: target_pool.settings.primary_reads_enabled,
             pool_settings: target_pool.settings,
-            client_routing_mode: client_routing_mode
+            client_routing_mode: client_routing_mode,
         }
     }
 
@@ -346,7 +346,7 @@ impl QueryRouter {
         match self.client_routing_mode {
             ClientRoutingMode::Default => self.active_role,
             ClientRoutingMode::Reader => Some(Role::Replica),
-            ClientRoutingMode::Writer => Some(Role::Primary)
+            ClientRoutingMode::Writer => Some(Role::Primary),
         }
     }
 

--- a/tests/ruby/tests.rb
+++ b/tests/ruby/tests.rb
@@ -128,3 +128,25 @@ end
 25.times do
   poorly_behaved_client
 end
+
+
+# Test reader/writer endpoints
+def test_reader_writer_endpoints
+  conn = PG::connect("postgres://sharding_user:sharding_user@127.0.0.1:6432/sharded_db/reader?application_name=testing_pgcat")
+  conn.async_exec 'BEGIN'
+  conn.async_exec 'SELECT 1'
+  conn.async_exec 'COMMIT'
+  conn.close
+
+  conn = PG::connect("postgres://sharding_user:sharding_user@127.0.0.1:6432/sharded_db/writer?application_name=testing_pgcat")
+  conn.async_exec 'BEGIN'
+  conn.async_exec 'SELECT 1'
+  conn.async_exec 'COMMIT'
+  conn.close
+
+  puts 'Reader/Writer clients ok'
+end
+
+25.times do
+  poorly_behaved_client
+end

--- a/tests/ruby/tests.rb
+++ b/tests/ruby/tests.rb
@@ -147,6 +147,4 @@ def test_reader_writer_endpoints
   puts 'Reader/Writer clients ok'
 end
 
-25.times do
-  poorly_behaved_client
-end
+test_reader_writer_endpoints


### PR DESCRIPTION
Experimenting with Reader/Writer endpoints


With this PR, connecting with `postgres://sharding_user:sharding_user@localhost:6432/sharded/writer` is equivalent to connecting to `postgres://sharding_user:sharding_user@localhost:6432/sharded` and then setting role to `primary` before each query. 
Connecting with `postgres://sharding_user:sharding_user@localhost:6432/sharded/reader` is equivalent to connecting to `postgres://sharding_user:sharding_user@localhost:6432/sharded` and then setting role to `replica` before each query. 

This is useful for clients that maintain their own primary/replica pools but do not have ability ban bad replicas or load balance (e.g. a vanilla Rails 6 app).

