### PR TITLE
Slightly more light weight health check

### DIFF
--- a/.circleci/pgcat.toml
+++ b/.circleci/pgcat.toml
@@ -14,7 +14,7 @@ port = 6432
 # How long to wait before aborting a server connection (ms).
 connect_timeout = 100
 
-# How much time to give `SELECT 1` health check query to return with a result (ms).
+# How much time to give the health check query to return with a result (ms).
 healthcheck_timeout = 100
 
 # For how long to ban a server if it fails a health check (seconds).

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -328,7 +328,7 @@ impl ConnectionPool {
 
             match tokio::time::timeout(
                 tokio::time::Duration::from_millis(healthcheck_timeout),
-                server.query("SELECT 1"),
+                server.query(";"),
             )
             .await
             {


### PR DESCRIPTION
Gitlab folks updated Rails connection health check to be `;` instead of `SELECT 1` because the empty query skips the query planner which makes the health check a tad bit easier on the database. [Gitlab PR](https://gitlab.com/gitlab-org/gitlab/-/issues/220055#note_463405732), [Rails PR](https://github.com/rails/rails/pull/42368)

Rails health checks are probably much more expensive given we run orders of magnitude more Rails processes than Pgcat processes. Nevertheless, I don't think it hurts to make the health checks less expensive.

