### PR TITLE
Sync pgcat config for docker-compose

### DIFF
--- a/examples/docker/pgcat.toml
+++ b/examples/docker/pgcat.toml
@@ -5,20 +5,11 @@
 #
 # General pooler settings
 [general]
-
 # What IP to run on, 0.0.0.0 means accessible from everywhere.
 host = "0.0.0.0"
 
 # Port to run on, same as PgBouncer used in this example.
 port = 6432
-
-# How many connections to allocate per server.
-pool_size = 15
-
-# Pool mode (see PgBouncer docs for more).
-# session: one server connection per connected client
-# transaction: one server connection per client transaction
-pool_mode = "transaction"
 
 # How long to wait before aborting a server connection (ms).
 connect_timeout = 5000
@@ -27,52 +18,29 @@ connect_timeout = 5000
 healthcheck_timeout = 1000
 
 # For how long to ban a server if it fails a health check (seconds).
-ban_time = 60 # Seconds
+ban_time = 60 # seconds
 
-#
-# User to use for authentication against the server.
-[user]
-name = "postgres"
-password = "postgres"
+# Reload config automatically if it changes.
+autoreload = false
 
+# TLS
+# tls_certificate = "server.cert"
+# tls_private_key = "server.key"
 
-#
-# Shards in the cluster
-[shards]
+# Credentials to access the virtual administrative database (pgbouncer or pgcat)
+# Connecting to that database allows running commands like `SHOW POOLS`, `SHOW DATABASES`, etc..
+admin_username = "postgres"
+admin_password = "postgres"
 
-# Shard 0
-[shards.0]
-
-# [ host, port, role ]
-servers = [
-    [ "postgres", 5432, "primary" ],
-    [ "postgres", 5432, "replica" ],
-    # [ "127.0.1.1", 5432, "replica" ],
-]
-# Database name (e.g. "postgres")
-database = "postgres"
-
-[shards.1]
-# [ host, port, role ]
-servers = [
-    [ "postgres", 5432, "primary" ],
-    [ "postgres", 5432, "replica" ],
-    # [ "127.0.1.1", 5432, "replica" ],
-]
-database = "postgres"
-
-[shards.2]
-# [ host, port, role ]
-servers = [
-    [ "postgres", 5432, "primary" ],
-    [ "postgres", 5432, "replica" ],
-    # [ "127.0.1.1", 5432, "replica" ],
-]
-database = "postgres"
-
-
-# Settings for our query routing layer.
-[query_router]
+# pool
+# configs are structured as pool.<pool_name>
+# the pool_name is what clients use as database name when connecting
+# For the example below a client can connect using "postgres://sharding_user:sharding_user@pgcat_host:pgcat_port/sharded"
+[pools.sharded]
+# Pool mode (see PgBouncer docs for more).
+# session: one server connection per connected client
+# transaction: one server connection per client transaction
+pool_mode = "transaction"
 
 # If the client doesn't specify, route traffic to
 # this role by default.
@@ -82,12 +50,11 @@ database = "postgres"
 # primary: all queries go to the primary unless otherwise specified.
 default_role = "any"
 
-
 # Query parser. If enabled, we'll attempt to parse
 # every incoming query to determine if it's a read or a write.
 # If it's a read query, we'll direct it to a replica. Otherwise, if it's a write,
 # we'll direct it to the primary.
-query_parser_enabled = false
+query_parser_enabled = true
 
 # If the query parser is enabled and this setting is enabled, the primary will be part of the pool of databases used for
 # load balancing of read queries. Otherwise, the primary will only be used for write
@@ -103,3 +70,61 @@ primary_reads_enabled = true
 # sha1: A hashing function based on SHA1
 #
 sharding_function = "pg_bigint_hash"
+
+# Credentials for users that may connect to this cluster
+[pools.sharded.users.0]
+username = "postgres"
+password = "postgres"
+# Maximum number of server connections that can be established for this user
+# The maximum number of connection from a single Pgcat process to any database in the cluster
+# is the sum of pool_size across all users.
+pool_size = 9
+
+[pools.sharded.users.1]
+username = "postgres"
+password = "postgres"
+pool_size = 21
+
+# Shard 0
+[pools.sharded.shards.0]
+# [ host, port, role ]
+servers = [
+    [ "postgres", 5432, "primary" ],
+    [ "postgres", 5432, "replica" ]
+]
+# Database name (e.g. "postgres")
+database = "postgres"
+
+[pools.sharded.shards.1]
+servers = [
+    [ "postgres", 5432, "primary" ],
+    [ "postgres", 5432, "replica" ],
+]
+database = "postgres"
+
+[pools.sharded.shards.2]
+servers = [
+    [ "postgres", 5432, "primary" ],
+    [ "postgres", 5432, "replica" ],
+]
+database = "postgres"
+
+
+[pools.simple_db]
+pool_mode = "session"
+default_role = "primary"
+query_parser_enabled = true
+primary_reads_enabled = true
+sharding_function = "pg_bigint_hash"
+
+[pools.simple_db.users.0]
+username = "postgres"
+password = "postgres"
+pool_size = 5
+
+[pools.simple_db.shards.0]
+servers = [
+    [ "postgres", 5432, "primary" ],
+    [ "postgres", 5432, "replica" ]
+]
+database = "postgres"


### PR DESCRIPTION
Realised that pgcat.toml used in docker-compose has deviated a lot from the one in root causing failure while starting the docker-compose environment

```
[2022-08-02T07:48:12Z ERROR pgcat::config] Could not parse config file: missing field `autoreload` for key `general` at line 75 column 1
[2022-08-02T07:48:12Z ERROR pgcat] Config parse error: BadConfig
```

Hence syncing it and changing 4 fields: username, password, database and host.