### PR TITLE
Fix Python tests and remove CircleCI-specific path

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ jobs:
           command: "cargo fmt --check"
       - run:
           name: "Install dependencies"
-          command: "sudo apt-get update && sudo apt-get install -y psmisc postgresql-contrib-12 postgresql-client-12 ruby ruby-dev libpq-dev python"
+          command: "sudo apt-get update && sudo apt-get install -y psmisc postgresql-contrib-12 postgresql-client-12 ruby ruby-dev libpq-dev python3 python3-pip"
       - run:
           name: "Build"
           command: "cargo build"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ jobs:
           command: "cargo fmt --check"
       - run:
           name: "Install dependencies"
-          command: "sudo apt-get update && sudo apt-get install -y psmisc postgresql-contrib-12 postgresql-client-12 ruby ruby-dev libpq-dev python3"
+          command: "sudo apt-get update && sudo apt-get install -y psmisc postgresql-contrib-12 postgresql-client-12 ruby ruby-dev libpq-dev python3 python3-pip"
       - run:
           name: "Build"
           command: "cargo build"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ jobs:
           command: "cargo fmt --check"
       - run:
           name: "Install dependencies"
-          command: "sudo apt-get update && sudo apt-get install -y psmisc postgresql-contrib-12 postgresql-client-12 ruby ruby-dev libpq-dev python3 python3-pip"
+          command: "sudo apt-get update && sudo apt-get install -y psmisc postgresql-contrib-12 postgresql-client-12 ruby ruby-dev libpq-dev python3"
       - run:
           name: "Build"
           command: "cargo build"

--- a/.circleci/run_tests.sh
+++ b/.circleci/run_tests.sh
@@ -72,15 +72,13 @@ cd tests/ruby && \
     ruby tests.rb
 cd ../..
 
-pwd
 #
 # Python tests
 #
 cd tests/python && \
-    pip install -r requirements.txt && \
-    python tests.py
+    pip3 install -r requirements.txt && \
+    python3 tests.py
 cd ../..
-pwd
 
 
 # Admin tests

--- a/.circleci/run_tests.sh
+++ b/.circleci/run_tests.sh
@@ -80,6 +80,7 @@ cd tests/python && \
     pip3 install -r requirements.txt && \
     python3 tests.py && \
     echo "Python Tests Done"
+echo $?
 cd ../..
 
 

--- a/.circleci/run_tests.sh
+++ b/.circleci/run_tests.sh
@@ -70,15 +70,16 @@ cd tests/ruby && \
     sudo gem install bundler && \
     bundle install && \
     ruby tests.rb
-cd /home/circleci/project
-
+cd
+pwd
 #
 # Python tests
 #
 cd tests/python && \
     pip install -r requirements.txt && \
     python tests.py
-cd /home/circleci/project
+cd
+pwd
 
 
 # Admin tests

--- a/.circleci/run_tests.sh
+++ b/.circleci/run_tests.sh
@@ -70,7 +70,8 @@ cd tests/ruby && \
     sudo gem install bundler && \
     bundle install && \
     ruby tests.rb
-cd
+cd ../..
+
 pwd
 #
 # Python tests
@@ -78,7 +79,7 @@ pwd
 cd tests/python && \
     pip install -r requirements.txt && \
     python tests.py
-cd
+cd ../..
 pwd
 
 

--- a/.circleci/run_tests.sh
+++ b/.circleci/run_tests.sh
@@ -69,7 +69,8 @@ psql -U sharding_user -e -h 127.0.0.1 -p 6432 -f tests/sharding/query_routing_te
 cd tests/ruby && \
     sudo gem install bundler && \
     bundle install && \
-    ruby tests.rb
+    ruby tests.rb && \
+    echo "Ruby Tests Done"
 cd ../..
 
 #
@@ -77,7 +78,8 @@ cd ../..
 #
 cd tests/python && \
     pip3 install -r requirements.txt && \
-    python3 tests.py
+    python3 tests.py && \
+    echo "Python Tests Done"
 cd ../..
 
 

--- a/.circleci/run_tests.sh
+++ b/.circleci/run_tests.sh
@@ -66,21 +66,18 @@ psql -U sharding_user -e -h 127.0.0.1 -p 6432 -f tests/sharding/query_routing_te
 #
 # ActiveRecord tests
 #
-cd tests/ruby && \
-    sudo gem install bundler && \
-    bundle install && \
-    ruby tests.rb && \
-    echo "Ruby Tests Done"
+cd tests/ruby
+sudo gem install bundler
+bundle install
+ruby tests.rb
 cd ../..
 
 #
 # Python tests
 #
-cd tests/python && \
-    pip3 install -r requirements.txt && \
-    python3 tests.py && \
-    echo "Python Tests Done"
-echo $?
+cd tests/python
+pip3 install -r requirements.txt
+python3 tests.py
 cd ../..
 
 

--- a/tests/python/tests.py
+++ b/tests/python/tests.py
@@ -10,7 +10,7 @@ def test_normal_db_access():
 
 
 def test_admin_db_access():
-    conn = psycopg2.connect("postgres://user:pass@127.0.0.1:6432/pgcat")
+    conn = psycopg2.connect("postgres://admin_user:admin_pass@127.0.0.1:6432/pgcat")
     conn.autocommit = True # BEGIN/COMMIT is not supported by admin db
     cur = conn.cursor()
 


### PR DESCRIPTION
Python tests were broken for a while but CircleCI didn't pick that signal up. 

This PR makes changes so that any failure during installation of test dependancies or during the test run itself will terminate the test suite with failure.

I also replaced CircleCI-specific path with relative paths