### PR TITLE
Add user to SHOW STATS query

### DIFF
--- a/src/admin.rs
+++ b/src/admin.rs
@@ -370,6 +370,7 @@ where
 {
     let columns = vec![
         ("database", DataType::Text),
+        ("user", DataType::Text),
         ("total_xact_count", DataType::Numeric),
         ("total_query_count", DataType::Numeric),
         ("total_received", DataType::Numeric),
@@ -390,7 +391,7 @@ where
     let mut res = BytesMut::new();
     res.put(row_description(&columns));
 
-    for (_, pool) in get_all_pools() {
+    for ((_db_name, user_name), pool) in get_all_pools() {
         for shard in 0..pool.shards() {
             for server in 0..pool.servers(shard) {
                 let address = pool.address(shard, server);
@@ -400,8 +401,9 @@ where
                 };
 
                 let mut row = vec![address.name()];
+                row.push(user_name.clone());
 
-                for column in &columns[1..] {
+                for column in &columns[2..] {
                     row.push(stats.get(column.0).unwrap_or(&0).to_string());
                 }
 


### PR DESCRIPTION
`SHOW STATS` query only shows database name and not the user. This can be confusing for viewers as they will see duplicate entries in each pool without justification

<img width="1684" alt="Screen Shot 2022-08-03 at 8 10 16 PM" src="https://user-images.githubusercontent.com/202050/182741536-e8c43ce6-fb36-4a18-bf80-69157edbe8e0.png">
