### PR TITLE
Report banned addresses as disabled

### DIFF
--- a/src/admin.rs
+++ b/src/admin.rs
@@ -252,10 +252,10 @@ where
         let pool_config = pool.settings.clone();
         for shard in 0..pool.shards() {
             let database_name = &pool_config.shards[&shard.to_string()].database;
-
             for server in 0..pool.servers(shard) {
                 let address = pool.address(shard, server);
                 let pool_state = pool.pool_state(shard, server);
+                let banned = pool.is_banned(address, shard, Some(address.role));
 
                 res.put(data_row(&vec![
                     address.name(),                         // name
@@ -270,7 +270,11 @@ where
                     pool_config.user.pool_size.to_string(), // max_connections
                     pool_state.connections.to_string(),     // current_connections
                     "0".to_string(),                        // paused
-                    "0".to_string(),                        // disabled
+                    match banned {
+                        // disabled
+                        true => "1".to_string(),
+                        false => "0".to_string(),
+                    },
                 ]));
             }
         }


### PR DESCRIPTION
We don't track banning events in admin databases. Banning events are pretty important and should be surfaced somewhere other than logs.

I opted for overloading the `disabled` field in the `SHOW DATABASE` view. This changes the semantics of `disabled` a bit. In Pgbouncer, a database is disabled by executing `DISABLE <database>` command against the admin database which will block new connections from being established against that database. 
In Pgcat, `disabled` would mean "temporarily banned". 

If we are not okay with this overload, we can just introduce another field in the `SHOW DATABASE` view.