### PR TITLE
fix docker compose port allocation for local dev

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,4 +14,4 @@ services:
       - "${PWD}/examples/docker/pgcat.toml:/etc/pgcat/pgcat.toml"
     ports:
       - "6432:6432"
-      - "9090:9090"
+      - "9930:9930"


### PR DESCRIPTION
I was testing https://github.com/levkk/pgcat/pull/107 on my machine outside of docker, but realized that inside docker the `9930` port isn't exposed 🤦 