### PR TITLE
Statement timeout + replica imbalance

### DIFF
--- a/.circleci/pgcat.toml
+++ b/.circleci/pgcat.toml
@@ -88,11 +88,13 @@ password = "sharding_user"
 # The maximum number of connection from a single Pgcat process to any database in the cluster
 # is the sum of pool_size across all users.
 pool_size = 9
+statement_timeout = 30000
 
 [pools.sharded_db.users.1]
 username = "other_user"
 password = "other_user"
 pool_size = 21
+statement_timeout = 30000
 
 # Shard 0
 [pools.sharded_db.shards.0]
@@ -130,6 +132,7 @@ sharding_function = "pg_bigint_hash"
 username = "simple_user"
 password = "simple_user"
 pool_size = 5
+statement_timeout = 30000
 
 [pools.simple_db.shards.0]
 servers = [

--- a/.circleci/pgcat.toml
+++ b/.circleci/pgcat.toml
@@ -88,7 +88,7 @@ password = "sharding_user"
 # The maximum number of connection from a single Pgcat process to any database in the cluster
 # is the sum of pool_size across all users.
 pool_size = 9
-statement_timeout = 30000
+statement_timeout = 0
 
 [pools.sharded_db.users.1]
 username = "other_user"

--- a/.circleci/run_tests.sh
+++ b/.circleci/run_tests.sh
@@ -66,6 +66,17 @@ psql -U sharding_user -e -h 127.0.0.1 -p 6432 -f tests/sharding/query_routing_te
 # Replica/primary selection & more sharding tests
 psql -U sharding_user -e -h 127.0.0.1 -p 6432 -f tests/sharding/query_routing_test_primary_replica.sql > /dev/null
 
+# Statement timeout tests
+sed -i 's/statement_timeout = 0/statement_timeout = 100/' .circleci/pgcat.toml
+kill -SIGHUP $(pgrep pgcat) # reload config
+sleep 0.2
+
+# This should timeout
+(! psql -U sharding_user -e -h 127.0.0.1 -p 6432 -c 'select pg_sleep(0.5)')
+
+# Disable statement timeout
+sed -i 's/statement_timeout = 100/statement_timeout = 0/' .circleci/pgcat.toml
+
 #
 # ActiveRecord tests
 #

--- a/.circleci/run_tests.sh
+++ b/.circleci/run_tests.sh
@@ -68,7 +68,7 @@ psql -U sharding_user -e -h 127.0.0.1 -p 6432 -f tests/sharding/query_routing_te
 
 # Statement timeout tests
 sed -i 's/statement_timeout = 0/statement_timeout = 100/' .circleci/pgcat.toml
-kill -SIGHUP $(pgrep pgcat) # reload config
+kill -SIGHUP $(pgrep pgcat) # Reload config
 sleep 0.2
 
 # This should timeout
@@ -76,6 +76,7 @@ sleep 0.2
 
 # Disable statement timeout
 sed -i 's/statement_timeout = 100/statement_timeout = 0/' .circleci/pgcat.toml
+kill -SIGHUP $(pgrep pgcat) # Reload config again
 
 #
 # ActiveRecord tests

--- a/pgcat.toml
+++ b/pgcat.toml
@@ -21,7 +21,7 @@ connect_timeout = 5000
 healthcheck_timeout = 1000
 
 # How long to keep connection available for immediate re-use, without running a healthcheck query on it
-healthcheck_delay = 1000
+healthcheck_delay = 30000
 
 # How much time to give clients during shutdown before forcibly killing client connections (ms).
 shutdown_timeout = 60000

--- a/pgcat.toml
+++ b/pgcat.toml
@@ -21,7 +21,7 @@ connect_timeout = 5000
 healthcheck_timeout = 1000
 
 # How long to keep connection available for immediate re-use, without running a healthcheck query on it
-healthcheck_delay = 30000
+healthcheck_delay = 1000
 
 # How much time to give clients during shutdown before forcibly killing client connections (ms).
 shutdown_timeout = 60000
@@ -89,10 +89,14 @@ password = "sharding_user"
 # is the sum of pool_size across all users.
 pool_size = 9
 
+# Maximum query duration. Dangerous, but protetcts against DBs that died and a non-obvious way.
+statement_timeout = 500
+
 [pools.sharded_db.users.1]
 username = "other_user"
 password = "other_user"
 pool_size = 21
+statement_timeout = 15000
 
 # Shard 0
 [pools.sharded_db.shards.0]
@@ -130,6 +134,7 @@ sharding_function = "pg_bigint_hash"
 username = "simple_user"
 password = "simple_user"
 pool_size = 5
+statement_timeout = 0
 
 [pools.simple_db.shards.0]
 servers = [

--- a/pgcat.toml
+++ b/pgcat.toml
@@ -90,7 +90,7 @@ password = "sharding_user"
 pool_size = 9
 
 # Maximum query duration. Dangerous, but protetcts against DBs that died and a non-obvious way.
-statement_timeout = 500
+statement_timeout = 0
 
 [pools.sharded_db.users.1]
 username = "other_user"

--- a/src/client.rs
+++ b/src/client.rs
@@ -986,7 +986,6 @@ where
                 Ok(result) => match result {
                     Ok(message) => Ok(message),
                     Err(err) => {
-                        server.mark_bad();
                         pool.ban(address, shard, self.process_id);
                         error_response_terminal(
                             &mut self.write,
@@ -1011,7 +1010,6 @@ where
             match server.recv().await {
                 Ok(message) => Ok(message),
                 Err(err) => {
-                    server.mark_bad();
                     pool.ban(address, shard, self.process_id);
                     error_response_terminal(
                         &mut self.write,

--- a/src/client.rs
+++ b/src/client.rs
@@ -988,7 +988,11 @@ where
                     Err(err) => {
                         server.mark_bad();
                         pool.ban(address, shard, self.process_id);
-                        error_response_terminal(&mut self.write, "pool statement timeout").await?;
+                        error_response_terminal(
+                            &mut self.write,
+                            &format!("error receiving data from server: {:?}", err),
+                        )
+                        .await?;
                         Err(err)
                     }
                 },
@@ -1009,7 +1013,11 @@ where
                 Err(err) => {
                     server.mark_bad();
                     pool.ban(address, shard, self.process_id);
-                    error_response_terminal(&mut self.write, "pool statement timeout").await?;
+                    error_response_terminal(
+                        &mut self.write,
+                        &format!("error receiving data from server: {:?}", err),
+                    )
+                    .await?;
                     Err(err)
                 }
             }

--- a/src/client.rs
+++ b/src/client.rs
@@ -499,7 +499,7 @@ where
         // The query router determines where the query is going to go,
         // e.g. primary, replica, which shard.
         let mut query_router = QueryRouter::new();
-        let mut round_robin = 0;
+        let mut round_robin = rand::random();
 
         // Our custom protocol loop.
         // We expect the client to either start a transaction with regular queries

--- a/src/config.rs
+++ b/src/config.rs
@@ -100,6 +100,7 @@ pub struct User {
     pub username: String,
     pub password: String,
     pub pool_size: u32,
+    pub statement_timeout: u64,
 }
 
 impl Default for User {
@@ -108,6 +109,7 @@ impl Default for User {
             username: String::from("postgres"),
             password: String::new(),
             pool_size: 15,
+            statement_timeout: 0,
         }
     }
 }
@@ -326,6 +328,7 @@ impl Config {
         };
 
         for (pool_name, pool_config) in &self.pools {
+            // TODO: Make this output prettier (maybe a table?)
             info!("--- Settings for pool {} ---", pool_name);
             info!(
                 "Pool size from all users: {}",
@@ -340,8 +343,17 @@ impl Config {
             info!("Sharding function: {}", pool_config.sharding_function);
             info!("Primary reads: {}", pool_config.primary_reads_enabled);
             info!("Query router: {}", pool_config.query_parser_enabled);
+
+            // TODO: Make this prettier.
             info!("Number of shards: {}", pool_config.shards.len());
             info!("Number of users: {}", pool_config.users.len());
+
+            for user in &pool_config.users {
+                info!(
+                    "{} pool size: {}, statement timeout: {}",
+                    user.1.username, user.1.pool_size, user.1.statement_timeout
+                );
+            }
         }
     }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -11,4 +11,5 @@ pub enum Error {
     AllServersDown,
     ClientError,
     TlsError,
+    StatementTimeout,
 }


### PR DESCRIPTION
Add a `statement_timeout` that protects against servers that were not health checked and also sets a reasonable maximum query duration at the pooler.

Fix replica load balancing imbalance in the case when a client connects to only issue one query.