### PR TITLE
Add cl_idle to SHOW POOLS

### DIFF
--- a/src/admin.rs
+++ b/src/admin.rs
@@ -174,6 +174,7 @@ where
     let columns = vec![
         ("database", DataType::Text),
         ("user", DataType::Text),
+        ("cl_idle", DataType::Numeric),
         ("cl_active", DataType::Numeric),
         ("cl_waiting", DataType::Numeric),
         ("cl_cancel_req", DataType::Numeric),


### PR DESCRIPTION
We are collecting `cl_idle` metric in stats but we never report it anywhere. This adds that statistic to `SHOW POOLS` query.

<img width="1337" alt="Screen Shot 2022-08-15 at 10 03 30 PM" src="https://user-images.githubusercontent.com/202050/184789463-767f7da3-0878-4980-9eda-569a4762f30b.png">

