### PR TITLE
Add pool name and username to address object

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -89,11 +89,11 @@ impl Address {
     /// Address name (aka database) used in `SHOW STATS`, `SHOW DATABASES`, and `SHOW POOLS`.
     pub fn name(&self) -> String {
         match self.role {
-            Role::Primary => format!("{}_shard_{}_primary", self.database, self.shard),
+            Role::Primary => format!("{}_shard_{}_primary", self.poolname, self.shard),
 
             Role::Replica => format!(
                 "{}_shard_{}_replica_{}",
-                self.database, self.shard, self.replica_number
+                self.poolname, self.shard, self.replica_number
             ),
         }
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -80,7 +80,6 @@ impl Default for Address {
             role: Role::Replica,
             username: String::from("username"),
             poolname: String::from("poolname"),
-
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -64,6 +64,8 @@ pub struct Address {
     pub database: String,
     pub role: Role,
     pub replica_number: usize,
+    pub username: String,
+    pub poolname: String,
 }
 
 impl Default for Address {
@@ -76,6 +78,9 @@ impl Default for Address {
             replica_number: 0,
             database: String::from("database"),
             role: Role::Replica,
+            username: String::from("username"),
+            poolname: String::from("poolname"),
+
         }
     }
 }

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -114,7 +114,7 @@ impl ConnectionPool {
 
                         let address = Address {
                             id: address_id,
-                            database: pool_name.clone(),
+                            database: shard.database.clone(),
                             host: server.0.clone(),
                             port: server.1.to_string(),
                             role: role,

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -120,6 +120,8 @@ impl ConnectionPool {
                             role: role,
                             replica_number,
                             shard: shard_idx.parse::<usize>().unwrap(),
+                            username: user_info.username.clone(),
+                            poolname: pool_name.clone(),
                         };
 
                         address_id += 1;


### PR DESCRIPTION
Pool name and Username are used as identifiers for individual pools in Pgcat. This data is very difficult to extract from individual `Address` objects. We need to extract that information to make logs and (in the future, metrics) more useful. Currently banning log messages looks like
```
Banning Address { id: 7, host: "host_name", port: "5432", shard: 0, database: "db_name", role: Primary, replica_number: 0 }
```
It would be great if we get information about the pool name and username for the pool this address came from.
