### PR TITLE
Change banning logic on connection checkout

### DIFF
--- a/src/pool.rs
+++ b/src/pool.rs
@@ -316,7 +316,6 @@ impl ConnectionPool {
             let mut conn = match self.databases[shard][index].get().await {
                 Ok(conn) => conn,
                 Err(err) => {
-
                     match err {
                         RunError::TimedOut => {
                             warn!("Timed out trying to get connection from replica {}", index);


### PR DESCRIPTION
This PR helps to differentiate timeouts from db errors to determine banning behaviour

We currently ban in the case of a timeout when checking out from the pool. This is not an issue with the DB but rather the pool is exhausted. We should try a different pool instead.

