### PR TITLE
Minor refactor to decouple config from the rest of the app

### DIFF
--- a/src/admin.rs
+++ b/src/admin.rs
@@ -3,12 +3,12 @@ use bytes::{Buf, BufMut, BytesMut};
 use log::{info, trace};
 use std::collections::HashMap;
 
-use crate::config::{get_config, reload_config, VERSION};
+use crate::config::{get_config, VERSION};
 use crate::errors::Error;
-use crate::messages::*;
 use crate::pool::get_all_pools;
 use crate::stats::get_stats;
 use crate::ClientServerMap;
+use crate::{messages::*, reload_config};
 
 pub fn generate_server_info_for_admin() -> BytesMut {
     let mut server_info = BytesMut::new();

--- a/src/config.rs
+++ b/src/config.rs
@@ -13,7 +13,6 @@ use toml;
 
 use crate::errors::Error;
 use crate::tls::{load_certs, load_keys};
-use crate::{ClientServerMap, ConnectionPool};
 
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 
@@ -523,28 +522,6 @@ pub async fn parse(path: &str) -> Result<(), Error> {
     CONFIG.store(Arc::new(config.clone()));
 
     Ok(())
-}
-
-pub async fn reload_config(client_server_map: ClientServerMap) -> Result<bool, Error> {
-    let old_config = get_config();
-    match parse(&old_config.path).await {
-        Ok(()) => (),
-        Err(err) => {
-            error!("Config reload error: {:?}", err);
-            return Err(Error::BadConfig);
-        }
-    };
-    let new_config = get_config();
-
-    if old_config.pools != new_config.pools {
-        info!("Pool configuration changed, re-creating server pools");
-        ConnectionPool::from_config(client_server_map).await?;
-        Ok(true)
-    } else if old_config != new_config {
-        Ok(true)
-    } else {
-        Ok(false)
-    }
 }
 
 #[cfg(test)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,6 +36,7 @@ extern crate tokio;
 extern crate tokio_rustls;
 extern crate toml;
 
+use config::parse;
 use log::{debug, error, info};
 use parking_lot::Mutex;
 use tokio::net::TcpListener;
@@ -65,7 +66,8 @@ mod sharding;
 mod stats;
 mod tls;
 
-use crate::config::{get_config, reload_config, VERSION};
+use crate::config::{get_config, VERSION};
+use crate::errors::Error;
 use crate::pool::{ClientServerMap, ConnectionPool};
 use crate::prometheus::start_metric_server;
 use crate::stats::{Collector, Reporter, REPORTER};
@@ -339,4 +341,26 @@ fn format_duration(duration: &chrono::Duration) -> String {
     let days = duration.num_days().to_string();
 
     format!("{}d {}:{}:{}", days, hours, minutes, seconds)
+}
+
+async fn reload_config(client_server_map: ClientServerMap) -> Result<bool, Error> {
+    let old_config = get_config();
+    match parse(&old_config.path).await {
+        Ok(()) => (),
+        Err(err) => {
+            error!("Config reload error: {:?}", err);
+            return Err(Error::BadConfig);
+        }
+    };
+    let new_config = get_config();
+
+    if old_config.pools != new_config.pools {
+        info!("Pool configuration changed, re-creating server pools");
+        ConnectionPool::from_config(client_server_map).await?;
+        Ok(true)
+    } else if old_config != new_config {
+        Ok(true)
+    } else {
+        Ok(false)
+    }
 }


### PR DESCRIPTION
Today, if we want to import `config` crate, we have to import the entire universe because `reload_config` references `ConnectionPool` and importing `ConnectionPool` cascades into importing the entire app.

This refactor removes `reload_config` from `config.rs` and places it in `main.rs`

This will allow us to import the config crate into external binaries that want to serialize/deserialize configs without having to import the entire app.