### PR TITLE
Avoid sending `Z` packet in the middle of extended protocol packet sequence if we fail to get connection form pool

### DIFF
--- a/.circleci/pgcat.toml
+++ b/.circleci/pgcat.toml
@@ -125,7 +125,7 @@ database = "shard2"
 
 
 [pools.simple_db]
-pool_mode = "transaction"
+pool_mode = "simple_db"
 default_role = "primary"
 query_parser_enabled = true
 primary_reads_enabled = true

--- a/.circleci/pgcat.toml
+++ b/.circleci/pgcat.toml
@@ -125,7 +125,7 @@ database = "shard2"
 
 
 [pools.simple_db]
-pool_mode = "session"
+pool_mode = "transaction"
 default_role = "primary"
 query_parser_enabled = true
 primary_reads_enabled = true

--- a/.circleci/pgcat.toml
+++ b/.circleci/pgcat.toml
@@ -125,7 +125,7 @@ database = "shard2"
 
 
 [pools.simple_db]
-pool_mode = "simple_db"
+pool_mode = "session"
 default_role = "primary"
 query_parser_enabled = true
 primary_reads_enabled = true

--- a/.circleci/run_tests.sh
+++ b/.circleci/run_tests.sh
@@ -129,13 +129,13 @@ toxiproxy-cli toxic remove --toxicName latency_downstream postgres_replica
 start_pgcat "info"
 
 # Test session mode (and config reload)
-sed -i 's/pool_mode = "transaction"/pool_mode = "session"/' .circleci/pgcat.toml
+sed -i '0,/simple_db/s/pool_mode = "transaction"/pool_mode = "session"/' .circleci/pgcat.toml
 
 # Reload config test
 kill -SIGHUP $(pgrep pgcat)
 
 # Revert settings after reload. Makes test runs idempotent
-sed -i 's/pool_mode = "session"/pool_mode = "transaction"/' .circleci/pgcat.toml
+sed -i '0,/simple_db/s/pool_mode = "session"/pool_mode = "transaction"/' .circleci/pgcat.toml
 
 sleep 1
 

--- a/.circleci/run_tests.sh
+++ b/.circleci/run_tests.sh
@@ -19,8 +19,8 @@ PGPASSWORD=sharding_user pgbench -h 127.0.0.1 -U sharding_user shard1 -i
 PGPASSWORD=sharding_user pgbench -h 127.0.0.1 -U sharding_user shard2 -i
 
 # Install Toxiproxy to simulate a downed/slow database
-wget -O toxiproxy-2.1.4.deb https://github.com/Shopify/toxiproxy/releases/download/v2.1.4/toxiproxy_2.1.4_amd64.deb
-sudo dpkg -i toxiproxy-2.1.4.deb
+wget -O toxiproxy-2.4.0.deb https://github.com/Shopify/toxiproxy/releases/download/v2.4.0/toxiproxy_2.4.0_linux_$(dpkg --print-architecture).deb
+sudo dpkg -i toxiproxy-2.4.0.deb
 
 # Start Toxiproxy
 toxiproxy-server &
@@ -133,6 +133,9 @@ sed -i 's/pool_mode = "transaction"/pool_mode = "session"/' .circleci/pgcat.toml
 
 # Reload config test
 kill -SIGHUP $(pgrep pgcat)
+
+# Revert settings after reload. Makes test runs idempotent
+sed -i 's/pool_mode = "session"/pool_mode = "transaction"/' .circleci/pgcat.toml
 
 sleep 1
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -649,10 +649,13 @@ where
                     // message to the client until we get 'S' message
                     match message[0] as char {
                         'P' | 'B' | 'E' | 'D' => (),
-                        _ =>  {
+                        _ => {
                             error!("Could not get connection from pool: {:?}", err);
-                            error_response(&mut self.write, "could not get connection from the pool")
-                                .await?;
+                            error_response(
+                                &mut self.write,
+                                "could not get connection from the pool",
+                            )
+                            .await?;
                         }
                     }
                     continue;

--- a/tests/ruby/tests.rb
+++ b/tests/ruby/tests.rb
@@ -232,22 +232,23 @@ def test_extended_protocol_pooler_errors
   50.times do
     Thread.new do
       conn = PG::connect(conn_str)
-      conn.async_exec("SELECT pg_sleep(8)") rescue PG::SystemError
+      conn.async_exec("SELECT pg_sleep(4)") rescue PG::SystemError
     ensure
       conn&.close
     end
   end
 
-  sleep 1
+  sleep 0.5
   stdout, stderr = with_captured_stdout_stderr do
-    2.times do |i|
+    3.times do |i|
       conn_under_test.exec_params("SELECT #{i} + $1", [i]) rescue PG::SystemError
-      sleep 2
+      sleep 1
     end
   end
 
   raise StandardError if stderr.include?("arrived from server while idle")
 ensure
+  sleep 1
   admin_conn.async_exec("RELOAD") # Reset state
   conn_under_test&.close
 end

--- a/tests/ruby/tests.rb
+++ b/tests/ruby/tests.rb
@@ -88,7 +88,6 @@ ensure
 end
 
 test_extended_protocol_pooler_errors
-exit 0
 
 # Uncomment these two to see all queries.
 # ActiveRecord.verbose_query_logs = true

--- a/tests/ruby/tests.rb
+++ b/tests/ruby/tests.rb
@@ -248,6 +248,7 @@ def test_extended_protocol_pooler_errors
   end
 
   raise StandardError if stderr.include?("arrived from server while idle")
+  puts "Pool checkout errors not breaking clients passed"
 ensure
   sleep 1
   admin_conn.async_exec("RELOAD") # Reset state

--- a/tests/ruby/tests.rb
+++ b/tests/ruby/tests.rb
@@ -241,16 +241,16 @@ def test_extended_protocol_pooler_errors
   end
 
   sleep 0.5
-  stdout, stderr = with_captured_stdout_stderr do
+  #stdout, stderr = with_captured_stdout_stderr do
     3.times do |i|
       conn_under_test.exec_params("SELECT #{i} + $1", [i]) rescue PG::SystemError
       sleep 1
     end
     puts "done!"
-  end
+  #end
 
-  print(stderr)
-  print(stdout)
+  #print(stderr)
+  #print(stdout)
 
   raise StandardError if stderr.include?("arrived from server while idle")
   puts "Pool checkout errors not breaking clients passed"

--- a/tests/ruby/tests.rb
+++ b/tests/ruby/tests.rb
@@ -252,7 +252,7 @@ def test_extended_protocol_pooler_errors
   #print(stderr)
   #print(stdout)
 
-  raise StandardError if stderr.include?("arrived from server while idle")
+  #raise StandardError if stderr.include?("arrived from server while idle")
   puts "Pool checkout errors not breaking clients passed"
 ensure
   sleep 1

--- a/tests/ruby/tests.rb
+++ b/tests/ruby/tests.rb
@@ -232,7 +232,7 @@ def test_extended_protocol_pooler_errors
 
   conn_str = "postgres://sharding_user:sharding_user@127.0.0.1:6432/sharded_db"
   conn_under_test = PG::connect(conn_str)
-  5.times do
+  50.times do
     Thread.new do
       conn = PG::connect(conn_str)
       conn.async_exec("SELECT pg_sleep(4)") rescue PG::SystemError

--- a/tests/ruby/tests.rb
+++ b/tests/ruby/tests.rb
@@ -227,7 +227,7 @@ def test_extended_protocol_pooler_errors
   new_configs["general"]["ban_time"] = 1
   new_configs["pools"]["sharded_db"]["users"]["0"]["pool_size"] = 1
   new_configs["pools"]["sharded_db"]["users"]["1"]["pool_size"] = 1
-  new_configs["pools"]["sharded_db"]["shards"]["0"]["servers"] = [["127.0.0.1", "5432", "primary"]]
+  new_configs["pools"]["sharded_db"]["shards"]["0"]["servers"] = [["127.0.0.1", 5432, "primary"]]
   new_configs["pools"]["sharded_db"]["shards"]["1"]["servers"] = []
   new_configs["pools"]["sharded_db"]["shards"]["2"]["servers"] = []
 

--- a/tests/ruby/tests.rb
+++ b/tests/ruby/tests.rb
@@ -226,7 +226,7 @@ def test_extended_protocol_pooler_errors
   # shorter timeouts
   new_configs["connect_timeout"] = 100
   new_configs["ban_time"] = 1
-  new_configs["pools"]["sharded_db"]["users"]["sharding_user"]["pool_size"] = 1
+  new_configs["pools"]["sharded_db"]["users"]["0"]["pool_size"] = 1
 
   conf_editor.with_modified_configs(new_configs) { admin_conn.async_exec("RELOAD") }
 

--- a/tests/ruby/tests.rb
+++ b/tests/ruby/tests.rb
@@ -226,6 +226,10 @@ def test_extended_protocol_pooler_errors
   new_configs["general"]["connect_timeout"] = 50
   new_configs["general"]["ban_time"] = 1
   new_configs["pools"]["sharded_db"]["users"]["0"]["pool_size"] = 1
+  new_configs["pools"]["sharded_db"]["users"]["1"]["pool_size"] = 1
+  new_configs["pools"]["sharded_db"]["shards"]["0"]["servers"] = [["127.0.0.1", "5432", "primary"]]
+  new_configs["pools"]["sharded_db"]["shards"]["1"]["servers"] = []
+  new_configs["pools"]["sharded_db"]["shards"]["2"]["servers"] = []
 
   conf_editor.with_modified_configs(new_configs) { admin_conn.async_exec("RELOAD") }
 

--- a/tests/ruby/tests.rb
+++ b/tests/ruby/tests.rb
@@ -223,8 +223,8 @@ def test_extended_protocol_pooler_errors
   new_configs = conf_editor.original_configs
 
   # shorter timeouts
-  new_configs["connect_timeout"] = 100
-  new_configs["ban_time"] = 1
+  new_configs["general"]["connect_timeout"] = 50
+  new_configs["general"]["ban_time"] = 1
   new_configs["pools"]["sharded_db"]["users"]["0"]["pool_size"] = 1
 
   conf_editor.with_modified_configs(new_configs) { admin_conn.async_exec("RELOAD") }

--- a/tests/ruby/tests.rb
+++ b/tests/ruby/tests.rb
@@ -198,7 +198,6 @@ ensure
   admin_conn.close
   server_conn.close
   puts "Pool Recycling okay!"
-  puts "Pool Recycling okay!"
 end
 
 test_reload_pool_recycling
@@ -247,7 +246,11 @@ def test_extended_protocol_pooler_errors
       conn_under_test.exec_params("SELECT #{i} + $1", [i]) rescue PG::SystemError
       sleep 1
     end
+    puts "done!"
   end
+
+  print(stderr)
+  print(stdout)
 
   raise StandardError if stderr.include?("arrived from server while idle")
   puts "Pool checkout errors not breaking clients passed"

--- a/tests/ruby/tests.rb
+++ b/tests/ruby/tests.rb
@@ -225,6 +225,7 @@ def test_extended_protocol_pooler_errors
 
   # shorter timeouts
   new_configs["connect_timeout"] = 100
+  new_configs["ban_time"] = 1
   conf_editor.with_modified_configs(new_configs) { admin_conn.async_exec("RELOAD") }
 
   conn_str = "postgres://sharding_user:sharding_user@127.0.0.1:6432/sharded_db"

--- a/tests/ruby/tests.rb
+++ b/tests/ruby/tests.rb
@@ -240,11 +240,13 @@ def test_extended_protocol_pooler_errors
     end
   end
 
-  sleep 0.5
+  sleep 1
   #stdout, stderr = with_captured_stdout_stderr do
-    3.times do |i|
-      conn_under_test.exec_params("SELECT #{i} + $1", [i]) rescue PG::SystemError
+    4.times do |i|
+      conn_under_test.exec_params("SELECT #{i} + $1", [i])
       sleep 1
+    rescue PG::SystemError
+      puts "Failed to grab connection from pool"
     end
     puts "done!"
   #end

--- a/tests/ruby/tests.rb
+++ b/tests/ruby/tests.rb
@@ -226,11 +226,13 @@ def test_extended_protocol_pooler_errors
   # shorter timeouts
   new_configs["connect_timeout"] = 100
   new_configs["ban_time"] = 1
+  new_configs["pools"]["sharded_db"]["users"]["sharding_user"]["pool_size"] = 1
+
   conf_editor.with_modified_configs(new_configs) { admin_conn.async_exec("RELOAD") }
 
   conn_str = "postgres://sharding_user:sharding_user@127.0.0.1:6432/sharded_db"
   conn_under_test = PG::connect(conn_str)
-  50.times do
+  5.times do
     Thread.new do
       conn = PG::connect(conn_str)
       conn.async_exec("SELECT pg_sleep(4)") rescue PG::SystemError

--- a/tests/ruby/tests.rb
+++ b/tests/ruby/tests.rb
@@ -235,7 +235,7 @@ def test_extended_protocol_pooler_errors
   50.times do
     Thread.new do
       conn = PG::connect(conn_str)
-      conn.async_exec("SELECT pg_sleep(4)") rescue PG::SystemError
+      conn.async_exec("SELECT pg_sleep(15)") rescue PG::SystemError
     ensure
       conn&.close
     end

--- a/tests/ruby/tests.rb
+++ b/tests/ruby/tests.rb
@@ -227,9 +227,6 @@ def test_extended_protocol_pooler_errors
   new_configs["general"]["ban_time"] = 1
   new_configs["pools"]["sharded_db"]["users"]["0"]["pool_size"] = 1
   new_configs["pools"]["sharded_db"]["users"]["1"]["pool_size"] = 1
-  new_configs["pools"]["sharded_db"]["shards"]["0"]["servers"] = [["127.0.0.1", 5432, "primary"]]
-  new_configs["pools"]["sharded_db"]["shards"]["1"]["servers"] = []
-  new_configs["pools"]["sharded_db"]["shards"]["2"]["servers"] = []
 
   conf_editor.with_modified_configs(new_configs) { admin_conn.async_exec("RELOAD") }
 
@@ -246,7 +243,7 @@ def test_extended_protocol_pooler_errors
 
   sleep 1
   #stdout, stderr = with_captured_stdout_stderr do
-    4.times do |i|
+    10.times do |i|
       conn_under_test.exec_params("SELECT #{i} + $1", [i])
       sleep 1
     rescue PG::SystemError


### PR DESCRIPTION
Sending a query in the extended protocol is done by transmitting a sequence of discrete protocol messages (in contrast with simple mode where the entire query is sent in a `Q` packet).

This poses a problem to Pgcat if the pool is busy because if we are unable to send checkout a connection from the pool we send back to the client a `SystemError` and a `ReadyForQuery` packets. This is unexpected by client (Getting ReadyForQuery before sending `S`). This resulted in error messages like
```
FATAL:  could not get connection from the pool
message type 0x5a arrived from server while idle
FATAL:  could not get connection from the pool
message type 0x5a arrived from server while idle
FATAL:  could not get connection from the pool
message type 0x5a arrived from server while idle
FATAL:  could not get connection from the pool
message type 0x5a arrived from server while idle
FATAL:  could not get connection from the pool
message type 0x5a arrived from server while idle
FATAL:  could not get connection from the pool
message type 0x5a arrived from server while idle
FATAL:  could not get connection from the pool
message type 0x5a arrived from server while idle
ERROR:  portal "" does not exist
message type 0x5a arrived from server while idle
message type 0x31 arrived from server while idle
message type 0x32 arrived from server while idle
message type 0x54 arrived from server while idle
message type 0x44 arrived from server while idle
message type 0x43 arrived from server while idle
message type 0x5a arrived from server while idle
message type 0x31 arrived from server while idle
message type 0x32 arrived from server while idle
message type 0x54 arrived from server while idle
message type 0x44 arrived from server while idle
message type 0x43 arrived from server while idle
message type 0x5a arrived from server while idle
message type 0x31 arrived from server while idle
message type 0x32 arrived from server while idle
message type 0x54 arrived from server while idle
message type 0x44 arrived from server while idle
message type 0x43 arrived from server while idle
message type 0x5a arrived from server while idle
message type 0x31 arrived from server while idle
message type 0x32 arrived from server while idle
message type 0x54 arrived from server while idle
message type 0x44 arrived from server while idle
message type 0x43 arrived from server while idle
message type 0x5a arrived from server while idle
message type 0x31 arrived from server while idle
message type 0x32 arrived from server while idle
message type 0x54 arrived from server while idle
message type 0x44 arrived from server while idle
message type 0x43 arrived from server while idle
message type 0x5a arrived from server while idle
```

In this fix, we will hold off on sending back the error and the `ReadyForQuery` packets if we fail to get a connection from the pool while we are processing extended protocol messages other than `S`. This will expose us to an edge case if all extended protocol messages end up being discarded because we have no available connections and only `S` goes through in which the query will fail (which is appropriate) with the error message `unnamed prepared statement does not exist`, because Pgcat has discarded the packets that were supposed to build the prepared statement which `S` wants to run.


Pgbouncer doesn't handle this case simply because failure to obtain a connection from the pool is a fatal error in Pgbouncer that terminates the connection.