### PR TITLE
Allow admin connections during shutdown

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -167,6 +167,8 @@ async fn main() {
     tokio::task::spawn(async move {
         // Creates event subscriber for shutdown event, this is dropped when shutdown event is broadcast
         let mut listener_shutdown_event_rx = shutdown_event_tx_clone.subscribe();
+
+        // Main loop which uses the shutdown event channels to coordinate shutdown events for non-admin clients
         loop {
             let client_server_map = client_server_map.clone();
 
@@ -225,8 +227,11 @@ async fn main() {
             });
         }
 
+        // This drop is used to indicate to shutdown event receiver that there are no more transmitters in use
+        // this is the signal for the shutdown to complete
         drop(shutdown_event_tx_clone);
 
+        // This loop is used to accept only admin connections and doesn't make use of the shutdown event channels
         loop {
             let client_server_map = client_server_map.clone();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -202,6 +202,7 @@ async fn main() {
                     socket,
                     client_server_map,
                     Some(client_shutdown_handler_rx),
+                    false,
                 )
                 .await
                 {
@@ -246,6 +247,7 @@ async fn main() {
                     socket,
                     client_server_map,
                     None,
+                    true
                 )
                 .await
                 {

--- a/src/main.rs
+++ b/src/main.rs
@@ -224,9 +224,9 @@ async fn main() {
                 drop(dummy_tx);
             });
         }
-        
+
         drop(shutdown_event_tx_clone);
-        
+
         loop {
             let client_server_map = client_server_map.clone();
 
@@ -243,14 +243,7 @@ async fn main() {
             tokio::task::spawn(async move {
                 let start = chrono::offset::Utc::now().naive_utc();
 
-                match client::client_entrypoint(
-                    socket,
-                    client_server_map,
-                    None,
-                    true
-                )
-                .await
-                {
+                match client::client_entrypoint(socket, client_server_map, None, true).await {
                     Ok(_) => {
                         let duration = chrono::offset::Utc::now().naive_utc() - start;
 

--- a/tests/python/tests.py
+++ b/tests/python/tests.py
@@ -27,11 +27,22 @@ def pg_cat_send_signal(signal: signal.Signals):
             raise Exception("pgcat not closed after SIGTERM")
 
 
-def connect_normal_db(
+def connect_db(
     autocommit: bool = False,
+    admin: bool = False,
 ) -> Tuple[psycopg2.extensions.connection, psycopg2.extensions.cursor]:
+
+    if admin:
+        user = "admin_user"
+        password = "admin_pass"
+        db = "pgcat"
+    else:
+        user = "sharding_user"
+        password = "sharding_user"
+        db = "sharded_db"
+
     conn = psycopg2.connect(
-        f"postgres://sharding_user:sharding_user@{PGCAT_HOST}:{PGCAT_PORT}/sharded_db?application_name=testing_pgcat"
+        f"postgres://{user}:{password}@{PGCAT_HOST}:{PGCAT_PORT}/{db}?application_name=testing_pgcat"
     )
     conn.autocommit = autocommit
     cur = conn.cursor()
@@ -45,7 +56,7 @@ def cleanup_conn(conn: psycopg2.extensions.connection, cur: psycopg2.extensions.
 
 
 def test_normal_db_access():
-    conn, cur = connect_normal_db()
+    conn, cur = connect_db()
     cur.execute("SELECT 1")
     res = cur.fetchall()
     print(res)
@@ -53,11 +64,7 @@ def test_normal_db_access():
 
 
 def test_admin_db_access():
-    conn = psycopg2.connect(
-        f"postgres://admin_user:admin_pass@{PGCAT_HOST}:{PGCAT_PORT}/pgcat"
-    )
-    conn.autocommit = True  # BEGIN/COMMIT is not supported by admin db
-    cur = conn.cursor()
+    conn, cur = connect_db(autocommit=True, admin=True)
 
     cur.execute("SHOW POOLS")
     res = cur.fetchall()
@@ -67,7 +74,9 @@ def test_admin_db_access():
 
 def test_shutdown_logic():
 
-    ##### NO ACTIVE QUERIES SIGINT HANDLING #####
+    # - - - - - - - - - - - - - - - - - -
+    # NO ACTIVE QUERIES SIGINT HANDLING
+
     # Start pgcat
     pgcat_start()
 
@@ -75,7 +84,7 @@ def test_shutdown_logic():
     time.sleep(2)
 
     # Create client connection and send query (not in transaction)
-    conn, cur = connect_normal_db(True)
+    conn, cur = connect_db(autocommit=True)
 
     cur.execute("BEGIN;")
     cur.execute("SELECT 1;")
@@ -97,9 +106,9 @@ def test_shutdown_logic():
     cleanup_conn(conn, cur)
     pg_cat_send_signal(signal.SIGTERM)
 
-    ##### END #####
+    # - - - - - - - - - - - - - - - - - -
+    # HANDLE TRANSACTION WITH SIGINT
 
-    ##### HANDLE TRANSACTION WITH SIGINT #####
     # Start pgcat
     pgcat_start()
 
@@ -107,7 +116,7 @@ def test_shutdown_logic():
     time.sleep(2)
 
     # Create client connection and begin transaction
-    conn, cur = connect_normal_db(True)
+    conn, cur = connect_db(autocommit=True)
 
     cur.execute("BEGIN;")
     cur.execute("SELECT 1;")
@@ -126,9 +135,66 @@ def test_shutdown_logic():
     cleanup_conn(conn, cur)
     pg_cat_send_signal(signal.SIGTERM)
 
-    ##### END #####
+    # - - - - - - - - - - - - - - - - - -
+    # HANDLE NO NEW CONNECTIONS DURING SHUTDOWN
+    # Start pgcat
+    pgcat_start()
 
-    ##### HANDLE SHUTDOWN TIMEOUT WITH SIGINT #####
+    # Wait for server to fully start up
+    time.sleep(2)
+
+    # Create client connection and begin transaction
+    transaction_conn, transaction_cur = connect_db(autocommit=True)
+
+    transaction_cur.execute("BEGIN;")
+    transaction_cur.execute("SELECT 1;")
+
+    # Send sigint to pgcat while still in transaction
+    pg_cat_send_signal(signal.SIGINT)
+    time.sleep(1)
+
+    try:
+        conn, cur = connect_db(autocommit=True)
+        cleanup_conn(conn, cur)
+    except psycopg2.OperationalError as e:
+        pass
+    else:
+        raise Exception("Able connect to database during shutdown")
+
+    cleanup_conn(transaction_conn, transaction_cur)
+    pg_cat_send_signal(signal.SIGTERM)
+
+    # - - - - - - - - - - - - - - - - - -
+    # HANDLE NEW ADMIN CONNECTIONS DURING SHUTDOWN
+    # Start pgcat
+    pgcat_start()
+
+    # Wait for server to fully start up
+    time.sleep(2)
+
+    # Create client connection and begin transaction
+    transaction_conn, transaction_cur = connect_db(autocommit=True)
+
+    transaction_cur.execute("BEGIN;")
+    transaction_cur.execute("SELECT 1;")
+
+    # Send sigint to pgcat while still in transaction
+    pg_cat_send_signal(signal.SIGINT)
+    time.sleep(1)
+
+    try:
+        conn, cur = connect_db(autocommit=True, admin=True)
+        cur.execute("SHOW DATABASES;")
+        cleanup_conn(conn, cur)
+    except psycopg2.OperationalError as e:
+        raise Exception(e)
+
+    cleanup_conn(transaction_conn, transaction_cur)
+    pg_cat_send_signal(signal.SIGTERM)
+
+    # - - - - - - - - - - - - - - - - - -
+    # HANDLE SHUTDOWN TIMEOUT WITH SIGINT
+
     # Start pgcat
     pgcat_start()
 
@@ -136,7 +202,7 @@ def test_shutdown_logic():
     time.sleep(3)
 
     # Create client connection and begin transaction, which should prevent server shutdown unless shutdown timeout is reached
-    conn, cur = connect_normal_db(True)
+    conn, cur = connect_db(autocommit=True)
 
     cur.execute("BEGIN;")
     cur.execute("SELECT 1;")
@@ -159,7 +225,7 @@ def test_shutdown_logic():
     cleanup_conn(conn, cur)
     pg_cat_send_signal(signal.SIGTERM)
 
-    ##### END #####
+    # - - - - - - - - - - - - - - - - - -
 
 
 test_normal_db_access()


### PR DESCRIPTION
We ran into an issue around task termination that is a departure from Pgbouncer behavior.
So, when Pgbouncer receives SIGINT it will start draining connections but will allow new connections to be established to the admin db (and even run queries). Pgcat shutdown logic will reject all new connections when it is in drainage mode, this blocks queries against admin db during shutdown.

While this appears benign, it ended up being problematic in our setup because we have container health checks that query the admin db so once SIGINT was received by the old tasks, all of them failed health checks and were deregistered so for a several seconds we had 0 healthy tasks which caused application errors.