### PR TITLE
Allow admin clients to connect during shutdown

### DIFF
--- a/.circleci/run_tests.sh
+++ b/.circleci/run_tests.sh
@@ -6,7 +6,7 @@ set -o xtrace
 # Start PgCat with a particular log level
 # for inspection.
 function start_pgcat() {
-    kill -s SIGINT $(pgrep pgcat) || true
+    kill -s SIGTERM $(pgrep pgcat) || true
     RUST_LOG=${1} ./target/debug/pgcat .circleci/pgcat.toml &
     sleep 1
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -348,7 +348,10 @@ where
 
         // Only allow admin connection when in admin mode
         if admin_only && !admin {
-            debug!("Rejecting non-admin connection to {} when in admin only mode", target_pool_name);
+            debug!(
+                "Rejecting non-admin connection to {} when in admin only mode",
+                target_pool_name
+            );
             error_response_terminal(
                 &mut write,
                 &format!("terminating connection due to administrator command"),
@@ -1055,7 +1058,6 @@ where
 
 impl<S, T> Drop for Client<S, T> {
     fn drop(&mut self) {
-
         if !self.admin {
             ACTIVE_NON_ADMIN_CLIENTS.fetch_sub(1, Ordering::Relaxed);
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -335,15 +335,18 @@ fn format_duration(duration: &chrono::Duration) -> String {
     format!("{}d {}:{}:{}", days, hours, minutes, seconds)
 }
 
+
+
+
 async fn all_clients_evicted() {
-    let mut interval = tokio::time::interval(tokio::time::Duration::from_millis(1000));
+    let mut interval = tokio::time::interval(tokio::time::Duration::from_millis(500));
     loop {
-        interval.tick().await;
         let num_clients = ACTIVE_NON_ADMIN_CLIENTS.load(Ordering::Relaxed);
 
         if num_clients == 0 {
             info!("All clients evicted");
             break;
         }
+        interval.tick().await;
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -336,7 +336,7 @@ fn format_duration(duration: &chrono::Duration) -> String {
 }
 
 async fn all_clients_evicted() {
-    let mut interval = tokio::time::interval(tokio::time::Duration::from_millis(500));
+    let mut interval = tokio::time::interval(tokio::time::Duration::from_millis(100));
     loop {
         let num_clients = ACTIVE_NON_ADMIN_CLIENTS.load(Ordering::Relaxed);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -335,9 +335,6 @@ fn format_duration(duration: &chrono::Duration) -> String {
     format!("{}d {}:{}:{}", days, hours, minutes, seconds)
 }
 
-
-
-
 async fn all_clients_evicted() {
     let mut interval = tokio::time::interval(tokio::time::Duration::from_millis(500));
     loop {

--- a/tests/python/tests.py
+++ b/tests/python/tests.py
@@ -186,8 +186,6 @@ def test_shutdown_logic():
     # Start pgcat
     pgcat_start()
 
-    print("GOOD STUFF")
-
     # Create client connection and begin transaction
     transaction_conn, transaction_cur = connect_db(autocommit=True)
     transaction_cur.execute("BEGIN;")

--- a/tests/python/tests.py
+++ b/tests/python/tests.py
@@ -43,7 +43,8 @@ def connect_db(
         db = "sharded_db"
 
     conn = psycopg2.connect(
-        f"postgres://{user}:{password}@{PGCAT_HOST}:{PGCAT_PORT}/{db}?application_name=testing_pgcat"
+        f"postgres://{user}:{password}@{PGCAT_HOST}:{PGCAT_PORT}/{db}?application_name=testing_pgcat",
+        connect_timeout=2,
     )
     conn.autocommit = autocommit
     cur = conn.cursor()

--- a/tests/python/tests.py
+++ b/tests/python/tests.py
@@ -145,10 +145,14 @@ def test_shutdown_logic():
     pg_cat_send_signal(signal.SIGINT)
     time.sleep(1)
 
+    start = time.perf_counter()
     try:
         conn, cur = connect_db(autocommit=True)
         cleanup_conn(conn, cur)
     except psycopg2.OperationalError as e:
+        time_taken = time.perf_counter() - start
+        if time_taken > 0.1:
+            raise Exception("Failed to reject connection within 0.1 seconds, got", time_taken, "seconds")
         pass
     else:
         raise Exception("Able connect to database during shutdown")


### PR DESCRIPTION
We ran into an issue around task termination that is a departure from Pgbouncer behavior.
So, when Pgbouncer receives SIGINT it will start draining connections but will allow new connections to be established to the admin db (and even run queries). Pgcat shutdown logic will reject all new connections when it is in drainage mode, this blocks queries against admin db during shutdown.

While this appears benign, it ended up being problematic in our setup because we have container health checks that query the admin db so once SIGINT was received by the old tasks, all of them failed health checks and were deregistered so for a several seconds we had 0 healthy tasks which caused application errors.

Changes
- replaces the transmitter closed error logic for determining closed clients with an atomic counter that keeps track of all active non-admin client connections
- Introduces creating clients in admin only mode which allows admin connections to function regardless of shutdown state, and rejects any new non-admin client connections