### PR TITLE
Support settings custom search path

### DIFF
--- a/.circleci/pgcat.toml
+++ b/.circleci/pgcat.toml
@@ -108,6 +108,7 @@ servers = [
 ]
 # Database name (e.g. "postgres")
 database = "shard0"
+search_path = "\"$user\",public"
 
 [pools.sharded_db.shards.1]
 servers = [

--- a/src/client.rs
+++ b/src/client.rs
@@ -354,8 +354,6 @@ where
         let stats = get_reporter();
         let parameters = parse_startup(bytes.clone())?;
 
-        info!("params: {:?}", parameters);
-
         // These two parameters are mandatory by the protocol.
         let pool_name = match parameters.get("database") {
             Some(db) => db,

--- a/src/client.rs
+++ b/src/client.rs
@@ -354,6 +354,8 @@ where
         let stats = get_reporter();
         let parameters = parse_startup(bytes.clone())?;
 
+        info!("params: {:?}", parameters);
+
         // These two parameters are mandatory by the protocol.
         let pool_name = match parameters.get("database") {
             Some(db) => db,
@@ -644,8 +646,8 @@ where
 
                 // SET SHARD TO
                 Some((Command::SetShard, _)) => {
-                    // Selected shard is not configured.
-                    if query_router.shard() >= pool.shards() {
+                    let shard = query_router.shard();
+                    if shard >= pool.shards() {
                         // Set the shard back to what it was.
                         query_router.set_shard(current_shard);
 
@@ -653,7 +655,7 @@ where
                             &mut self.write,
                             &format!(
                                 "shard {} is more than configured {}, staying on shard {}",
-                                query_router.shard(),
+                                shard,
                                 pool.shards(),
                                 current_shard,
                             ),

--- a/src/config.rs
+++ b/src/config.rs
@@ -72,6 +72,9 @@ pub struct Address {
     /// The name of the Postgres database.
     pub database: String,
 
+    /// Default search_path.
+    pub search_path: Option<String>,
+
     /// Server role: replica, primary.
     pub role: Role,
 
@@ -98,6 +101,7 @@ impl Default for Address {
             address_index: 0,
             replica_number: 0,
             database: String::from("database"),
+            search_path: None,
             role: Role::Replica,
             username: String::from("username"),
             pool_name: String::from("pool_name"),
@@ -206,6 +210,7 @@ impl Default for Pool {
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct Shard {
     pub database: String,
+    pub search_path: Option<String>,
     pub servers: Vec<(String, u16, String)>,
 }
 
@@ -213,6 +218,7 @@ impl Default for Shard {
     fn default() -> Shard {
         Shard {
             servers: vec![(String::from("localhost"), 5432, String::from("primary"))],
+            search_path: None,
             database: String::from("postgres"),
         }
     }

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -155,6 +155,7 @@ impl ConnectionPool {
                         let address = Address {
                             id: address_id,
                             database: shard.database.clone(),
+                            search_path: shard.search_path.clone(),
                             host: server.0.clone(),
                             port: server.1 as u16,
                             role: role,

--- a/src/server.rs
+++ b/src/server.rs
@@ -86,7 +86,13 @@ impl Server {
         trace!("Sending StartupMessage");
 
         // StartupMessage
-        startup(&mut stream, &user.username, database).await?;
+        startup(
+            &mut stream,
+            &user.username,
+            database,
+            address.search_path.as_ref(),
+        )
+        .await?;
 
         let mut server_info = BytesMut::new();
         let mut process_id: i32 = 0;


### PR DESCRIPTION
1. Add `search_path` configuration open to shards.
2. Fix showing incorrect shard when setting a shard to an unsupported number (just a display error bug).