### PR TITLE
Send DISCARD ALL even if client is not in transaction

### DIFF
--- a/.circleci/run_tests.sh
+++ b/.circleci/run_tests.sh
@@ -90,8 +90,8 @@ kill -SIGHUP $(pgrep pgcat) # Reload config again
 cd tests/ruby
 sudo gem install bundler
 bundle install
-bundle exec ruby tests.rb
-bundle exec rspec *_spec.rb
+bundle exec ruby tests.rb || exit 1
+bundle exec rspec *_spec.rb || exit 1
 cd ../..
 
 #
@@ -99,7 +99,7 @@ cd ../..
 # These tests will start and stop the pgcat server so it will need to be restarted after the tests
 #
 pip3 install -r tests/python/requirements.txt
-python3 tests/python/tests.py
+python3 tests/python/tests.py || exit 1
 
 start_pgcat "info"
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -575,11 +575,22 @@ impl Server {
         Ok(())
     }
 
+    /// Perform any necessary cleanup before putting the server
+    /// connection back in the pool
     pub async fn checkin_cleanup(&mut self) -> Result<(), Error> {
+        // Client disconnected with an open transaction on the server connection
+        // Pgbouncer behavior is to close the server connection but that can cause
+        // server connection thrashing if clients repeatedly do this.
+        // Instead, we Roll that transaction back before putting the connection back in the pool
         if self.in_transaction() {
             self.query("ROLLBACK").await?;
         }
 
+        // Client disconnected but it perfromed session-altering operations such as
+        // SET statement_timeout to 1 or create a prepared statement. We clear that
+        // to avoid leaking state between clients. For performance reasons we only
+        // send `DISCARD ALL` if we think the session is altered instead of just sending
+        // it before each checkin,
         if self.needs_cleanup {
             self.query("DISCARD ALL").await?;
             self.needs_cleanup = false;

--- a/src/server.rs
+++ b/src/server.rs
@@ -578,10 +578,10 @@ impl Server {
     /// Perform any necessary cleanup before putting the server
     /// connection back in the pool
     pub async fn checkin_cleanup(&mut self) -> Result<(), Error> {
-        // Client disconnected with an open transaction on the server connection
+        // Client disconnected with an open transaction on the server connection.
         // Pgbouncer behavior is to close the server connection but that can cause
         // server connection thrashing if clients repeatedly do this.
-        // Instead, we Roll that transaction back before putting the connection back in the pool
+        // Instead, we ROLLBACK that transaction before putting the connection back in the pool
         if self.in_transaction() {
             self.query("ROLLBACK").await?;
         }
@@ -590,7 +590,7 @@ impl Server {
         // SET statement_timeout to 1 or create a prepared statement. We clear that
         // to avoid leaking state between clients. For performance reasons we only
         // send `DISCARD ALL` if we think the session is altered instead of just sending
-        // it before each checkin,
+        // it before each checkin.
         if self.needs_cleanup {
             self.query("DISCARD ALL").await?;
             self.needs_cleanup = false;

--- a/src/server.rs
+++ b/src/server.rs
@@ -592,7 +592,6 @@ impl Server {
     pub fn last_activity(&self) -> SystemTime {
         self.last_activity
     }
-
 }
 
 impl Drop for Server {

--- a/src/server.rs
+++ b/src/server.rs
@@ -451,7 +451,7 @@ impl Server {
                     message.reader().read_to_string(&mut command_tag).unwrap();
 
                     // Non-exhaustive list of commands that are likely to change session variables/resources
-                    // which can leak between client. This is a best effort to block bad clients
+                    // which can leak between clients. This is a best effort to block bad clients
                     // from poisoning a transaction-mode pool by setting inappropriate session variables
                     match command_tag.as_str() {
                         "SET\0" | "PREPARE\0" => {

--- a/src/server.rs
+++ b/src/server.rs
@@ -553,6 +553,17 @@ impl Server {
         Ok(())
     }
 
+    pub async fn checkin_cleanup(&mut self) -> Result<(), Error> {
+        if self.in_transaction() {
+            self.query("ROLLBACK").await?;
+        }
+
+        self.query("DISCARD ALL").await?;
+        self.set_name("pgcat").await?;
+
+        return Ok(());
+    }
+
     /// A shorthand for `SET application_name = $1`.
     #[allow(dead_code)]
     pub async fn set_name(&mut self, name: &str) -> Result<(), Error> {
@@ -581,6 +592,7 @@ impl Server {
     pub fn last_activity(&self) -> SystemTime {
         self.last_activity
     }
+
 }
 
 impl Drop for Server {

--- a/tests/ruby/helpers/pgcat_helper.rb
+++ b/tests/ruby/helpers/pgcat_helper.rb
@@ -5,7 +5,7 @@ require_relative 'pg_instance'
 
 module Helpers
   module Pgcat
-    def self.three_shard_setup(pool_name, pool_size)
+    def self.three_shard_setup(pool_name, pool_size, pool_mode="transaction")
       user = {
         "password" => "sharding_user",
         "pool_size" => pool_size,
@@ -22,7 +22,7 @@ module Helpers
       pgcat_cfg["pools"] = {
         "#{pool_name}" => {
           "default_role" => "any",
-          "pool_mode" => "transaction",
+          "pool_mode" => pool_mode,
           "primary_reads_enabled" => false,
           "query_parser_enabled" => false,
           "sharding_function" => "pg_bigint_hash",
@@ -46,7 +46,7 @@ module Helpers
       end
     end
 
-    def self.single_shard_setup(pool_name, pool_size)
+    def self.single_shard_setup(pool_name, pool_size, pool_mode="transaction")
       user = {
         "password" => "sharding_user",
         "pool_size" => pool_size,
@@ -66,7 +66,7 @@ module Helpers
       pgcat_cfg["pools"] = {
         "#{pool_name}" => {
           "default_role" => "any",
-          "pool_mode" => "transaction",
+          "pool_mode" => pool_mode,
           "primary_reads_enabled" => false,
           "query_parser_enabled" => false,
           "sharding_function" => "pg_bigint_hash",

--- a/tests/ruby/misc_spec.rb
+++ b/tests/ruby/misc_spec.rb
@@ -106,4 +106,34 @@ describe "Miscellaneous" do
       admin_conn.close
     end
   end
+
+  describe "State clearance" do
+    context "session mode" do
+      let(:processes) { Helpers::Pgcat.single_shard_setup("sharded_db", 5, "session") }
+
+      it "Clears state before connection checkin" do
+        # Both modes of operation should not raise
+        # ERROR:  prepared statement "prepared_q" already exists
+        15.times do
+          conn = PG::connect(processes.pgcat.connection_string("sharded_db", "sharding_user"))
+          conn.async_exec("PREPARE prepared_q (int) AS SELECT $1")
+          conn.close
+        end
+      end
+    end
+
+    context "transaction mode" do
+      let(:processes) { Helpers::Pgcat.single_shard_setup("sharded_db", 5, "transaction") }
+
+      it "Clears state before connection checkin" do
+        # Both modes of operation should not raise
+        # ERROR:  prepared statement "prepared_q" already exists
+        15.times do
+          conn = PG::connect(processes.pgcat.connection_string("sharded_db", "sharding_user"))
+          conn.async_exec("PREPARE prepared_q (int) AS SELECT $1")
+          conn.close
+        end
+      end
+    end
+  end
 end

--- a/tests/ruby/misc_spec.rb
+++ b/tests/ruby/misc_spec.rb
@@ -91,7 +91,6 @@ describe "Miscellaneous" do
       conn.close
 
       expect(processes.primary.count_query("ROLLBACK")).to eq(1)
-      expect(processes.primary.count_query("DISCARD ALL")).to eq(1)
     end
   end
 
@@ -119,12 +118,39 @@ describe "Miscellaneous" do
           conn.async_exec("PREPARE prepared_q (int) AS SELECT $1")
           conn.close
         end
+
+        conn = PG::connect(processes.pgcat.connection_string("sharded_db", "sharding_user"))
+        initial_value = conn.async_exec("SHOW statement_timeout")[0]["statement_timeout"]
+        conn.async_exec("SET statement_timeout to 1000")
+        current_value = conn.async_exec("SHOW statement_timeout")[0]["statement_timeout"]
+        expect(conn.async_exec("SHOW statement_timeout")[0]["statement_timeout"]).to eq("1s")
+        conn.close
+      end
+
+      it "Does not send DISCARD ALL unless necessary" do
+        10.times do
+          conn = PG::connect(processes.pgcat.connection_string("sharded_db", "sharding_user"))
+          conn.async_exec("SET SERVER ROLE to 'primary'")
+          conn.async_exec("SELECT 1")
+          conn.close
+        end
+
+        expect(processes.primary.count_query("DISCARD ALL")).to eq(0)
+
+        10.times do
+          conn = PG::connect(processes.pgcat.connection_string("sharded_db", "sharding_user"))
+          conn.async_exec("SET SERVER ROLE to 'primary'")
+          conn.async_exec("SELECT 1")
+          conn.async_exec("SET statement_timeout to 5000")
+          conn.close
+        end
+
+        expect(processes.primary.count_query("DISCARD ALL")).to eq(10)
       end
     end
 
     context "transaction mode" do
       let(:processes) { Helpers::Pgcat.single_shard_setup("sharded_db", 5, "transaction") }
-
       it "Clears state before connection checkin" do
         # Both modes of operation should not raise
         # ERROR:  prepared statement "prepared_q" already exists
@@ -133,6 +159,27 @@ describe "Miscellaneous" do
           conn.async_exec("PREPARE prepared_q (int) AS SELECT $1")
           conn.close
         end
+      end
+
+      it "Does not send DISCARD ALL unless necessary" do
+        10.times do
+          conn = PG::connect(processes.pgcat.connection_string("sharded_db", "sharding_user"))
+          conn.async_exec("SET SERVER ROLE to 'primary'")
+          conn.async_exec("SELECT 1")
+          conn.close
+        end
+
+        expect(processes.primary.count_query("DISCARD ALL")).to eq(0)
+
+        10.times do
+          conn = PG::connect(processes.pgcat.connection_string("sharded_db", "sharding_user"))
+          conn.async_exec("SET SERVER ROLE to 'primary'")
+          conn.async_exec("SELECT 1")
+          conn.async_exec("SET statement_timeout to 5000")
+          conn.close
+        end
+
+        expect(processes.primary.count_query("DISCARD ALL")).to eq(10)
       end
     end
   end


### PR DESCRIPTION
We are not sending `DISCARD ALL` in all the situations that we should. This can leak session-specific settings/resources between clients.

This is currently easily reproducible by repeatedly running `PREPARE prepared_q (int) AS SELECT $1;` in psql until an error emerges.

I created a test to reproduce this issue and verified the fix. I am open to changing the name of the method.