### PR TITLE
Log Address information in connection create/drop

### DIFF
--- a/src/pool.rs
+++ b/src/pool.rs
@@ -559,11 +559,7 @@ impl ManageConnection for ServerPool {
 
     /// Attempts to create a new connection.
     async fn connect(&self) -> Result<Self::Connection, Self::Error> {
-        info!(
-            "Creating a new connection to {:?} using user {:?}",
-            self.address.name(),
-            self.user.username
-        );
+        info!("Creating a new server connection {:?}", self.address);
 
         // Put a temporary process_id into the stats
         // for server login.

--- a/src/server.rs
+++ b/src/server.rs
@@ -607,7 +607,8 @@ impl Drop for Server {
         let duration = now - self.connected_at;
 
         info!(
-            "Server connection closed, session duration: {}",
+            "Server connection closed {:?}, session duration: {}",
+            self.address,
             crate::format_duration(&duration)
         );
     }


### PR DESCRIPTION
Log `Address` object with server connection creation/disconnection to allow proper attribution to the user/pool/etc