### PR TITLE
Better handling extended protocol messages in the event of busy pool

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -608,7 +608,7 @@ where
             }
 
             match message[0] as char {
-                // Buffer Extended Protocol messages even if we do not have
+                // Buffer extended protocol messages even if we do not have
                 // a server connection yet. Hopefully, when we get the S message
                 // we'll be able to allocate a connection. Also, clients do not expect
                 // the server to respond to these messages so even if we were not able to
@@ -732,13 +732,11 @@ where
                     // We'll send back an error message and clean the extended
                     // protocol buffer
                     if message[0] as char == 'S' {
+                        error!("Got Sync message but failed to get a connection from the pool");
                         self.buffer.clear();
                     }
-                    error_response(
-                        &mut self.write,
-                        "could not get connection from the pool",
-                    )
-                    .await?;
+                    error_response(&mut self.write, "could not get connection from the pool")
+                        .await?;
                     error!("Could not get connection from pool: {:?}", err);
                     continue;
                 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -731,18 +731,15 @@ where
                     // but we were unable to grab a connection from the pool
                     // We'll send back an error message and clean the extended
                     // protocol buffer
-                    match message[0] as char {
-                        'S' => (),
-                        _ => {
-                            error_response(
-                                &mut self.write,
-                                "could not get connection from the pool",
-                            )
-                            .await?;
-                        }
-                    };
+                    if message[0] as char == 'S' {
+                        self.buffer.clear();
+                    }
+                    error_response(
+                        &mut self.write,
+                        "could not get connection from the pool",
+                    )
+                    .await?;
                     error!("Could not get connection from pool: {:?}", err);
-                    self.buffer.clear();
                     continue;
                 }
             };

--- a/src/client.rs
+++ b/src/client.rs
@@ -600,17 +600,30 @@ where
                 message_result = read_message(&mut self.read) => message_result?
             };
 
-            // Avoid taking a server if the client just wants to disconnect.
-            if message[0] as char == 'X' {
-                debug!("Client disconnecting");
-                return Ok(());
-            }
-
             // Handle admin database queries.
             if self.admin {
                 debug!("Handling admin command");
                 handle_admin(&mut self.write, message, self.client_server_map.clone()).await?;
                 continue;
+            }
+
+            match message[0] as char {
+                // Buffer Extended Protocol messages even if we do not have
+                // a server connection yet. Hopefully, when we get the S message
+                // we'll be able to allocate a connection. Also, clients do not expect
+                // the server to respond to these messages so even if we were not able to
+                // allocate a connection, we wouldn't be able to send back an error message
+                // to the client so we buffer them and defer the decision to error out or not
+                // to when we get the S message
+                'P' | 'B' | 'D' | 'E' => {
+                    self.buffer.put(&message[..]);
+                    continue;
+                }
+                'X' => {
+                    debug!("Client disconnecting");
+                    return Ok(());
+                }
+                _ => (),
             }
 
             // Get a pool instance referenced by the most up-to-date
@@ -714,11 +727,12 @@ where
                     conn
                 }
                 Err(err) => {
-                    // Clients do not expect to get SystemError followed by ReadyForQuery in the middle
-                    // of extended protocol submission. So we will hold off on sending the actual error
-                    // message to the client until we get 'S' message
+                    // Client is attempting to get results from the server,
+                    // but we were unable to grab a connection from the pool
+                    // We'll send back an error message and clean the extended
+                    // protocol buffer
                     match message[0] as char {
-                        'P' | 'B' | 'E' | 'D' => (),
+                        'S' => (),
                         _ => {
                             error_response(
                                 &mut self.write,
@@ -727,9 +741,8 @@ where
                             .await?;
                         }
                     };
-
                     error!("Could not get connection from pool: {:?}", err);
-
+                    self.buffer.clear();
                     continue;
                 }
             };


### PR DESCRIPTION
Let's imagine a Pgcat instance with single pool containing a single instance. The pool is fully occupied and all available connections are fully booked.

A client comes in, it connects and is now sitting idle in the external loop https://github.com/levkk/pgcat/blob/main/src/client.rs#L573

The client attempts to perform an extended protocol query. So first thing it does is send a `P` message. We try to grab a connection from the pool [here](https://github.com/levkk/pgcat/blob/main/src/client.rs#L708-L710) but we fail. This failure sends us to this [branch](https://github.com/levkk/pgcat/blob/main/src/client.rs#L717-L733) that ends with `continue`. The `P` message never got buffered because we buffer message in the inner loop [here](https://github.com/levkk/pgcat/blob/main/src/client.rs#L849-L851). Subsequent extended protocol messages meet similar fate and now the client sends a sync `S` message, This one manages to break through, so we are able to grab a connection and we enter the inner loop (The transaction loop) but we arrived here without any of the previous messages being buffered so we end up with errors like `ERROR: unnamed prepared statement does not exist` or `ERROR:  portal "" does not exist`. This does not affect clients that are already in the inner loop and have a server connection allocated. 

This change allows us to buffer the extended protocol message early without even checking out a connection from the pool.  The actual checkout will be performed when the `S` message arrives, at this point, we are guaranteed to have all messages buffered and have a client on the other end expecting a response. We can respond with `SystemError: Failed to get a connection from the Pool` or execute the query. 