### PR TITLE
Avoid reporting ProtocolSyncError when admin session disconnects

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -611,13 +611,6 @@ where
                 message_result = read_message(&mut self.read) => message_result?
             };
 
-            // Handle admin database queries.
-            if self.admin {
-                debug!("Handling admin command");
-                handle_admin(&mut self.write, message, self.client_server_map.clone()).await?;
-                continue;
-            }
-
             match message[0] as char {
                 // Buffer extended protocol messages even if we do not have
                 // a server connection yet. Hopefully, when we get the S message
@@ -635,6 +628,13 @@ where
                     return Ok(());
                 }
                 _ => (),
+            }
+
+            // Handle admin database queries.
+            if self.admin {
+                debug!("Handling admin command");
+                handle_admin(&mut self.write, message, self.client_server_map.clone()).await?;
+                continue;
             }
 
             // Get a pool instance referenced by the most up-to-date


### PR DESCRIPTION
We report `ProtocolSyncError` if we hit the admin handler codepath with any message other than `Q`. When we moved the `X` packet handling to happen with the extended protocol packets, we introduced a bug where we will report `ProtocolSyncError` every time admin client disconnects.

<img width="1503" alt="Screen Shot 2022-09-06 at 10 16 49 PM" src="https://user-images.githubusercontent.com/202050/188780929-aeb2227e-6bed-4e55-819e-b4a0565e592f.png">

This PR fixes this