### PR TITLE
Better logging for failure to get connection from pool

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -748,7 +748,9 @@ where
                     }
                     error_response(&mut self.write, "could not get connection from the pool")
                         .await?;
-                    error!("Could not get connection from pool: {:?}", err);
+
+                    error!("Could not get connection from pool: {{ pool_name: {:?}, username: {:?}, shard: {:?}, role: \"{:?}\", error: \"{:?}\" }}",
+                    self.pool_name.clone(), self.username.clone(), query_router.shard(), query_router.role(), err);
                     continue;
                 }
             };


### PR DESCRIPTION
Current logging does not tell us which pool we failed to acquired a connection from. This PR adds more useful information to the logs
```
Could not get connection from pool: { pool_name: "sharded_db", username: "sharding_user", shard: 0, role: "None", error: "AllServersDown" }
```