### PR TITLE
Almost automatic shard detection

### DIFF
--- a/pgcat.toml
+++ b/pgcat.toml
@@ -82,6 +82,7 @@ primary_reads_enabled = true
 # sha1: A hashing function based on SHA1
 #
 sharding_function = "pg_bigint_hash"
+sharding_key = "id"
 
 # Credentials for users that may connect to this cluster
 [pools.sharded_db.users.0]

--- a/src/client.rs
+++ b/src/client.rs
@@ -662,7 +662,7 @@ where
                 // Normal query, not a custom command.
                 None => {
                     if query_router.query_parser_enabled() {
-                        query_router.infer_role(message.clone());
+                        query_router.infer_role_and_shard(message.clone());
                     }
                 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -185,6 +185,7 @@ pub struct Pool {
     pub query_parser_enabled: bool,
     pub primary_reads_enabled: bool,
     pub sharding_function: String,
+    pub sharding_key: Option<String>,
     pub shards: HashMap<String, Shard>,
     pub users: HashMap<String, User>,
 }
@@ -198,6 +199,7 @@ impl Default for Pool {
             query_parser_enabled: false,
             primary_reads_enabled: true,
             sharding_function: "pg_bigint_hash".to_string(),
+            sharding_key: None,
         }
     }
 }


### PR DESCRIPTION
Automatically route to the right shard based on:

1. if `Q` (simple query), `sharding_key = <value>` or comment that says `/* sharding_key = <value> */`
2. if `P` (prepared, extended protocol), a comment that says `/* sharding_key = <value> */`

The more advanced version of this is to parse the SQL and get it out of `Q` and `B` packets depending on protocol. That one will require no modifications to clients (Ruby, Go, etc).