### PR TITLE
Minor refactor for configs

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -23,9 +23,9 @@ static CONFIG: Lazy<ArcSwap<Config>> = Lazy::new(|| ArcSwap::from_pointee(Config
 /// Server role: primary or replica.
 #[derive(Clone, PartialEq, Serialize, Deserialize, Hash, std::cmp::Eq, Debug, Copy)]
 pub enum Role {
-    #[serde(alias="primary", alias="Primary")]
+    #[serde(alias = "primary", alias = "Primary")]
     Primary,
-    #[serde(alias="replica", alias="Replica")]
+    #[serde(alias = "replica", alias = "Replica")]
     Replica,
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -23,7 +23,9 @@ static CONFIG: Lazy<ArcSwap<Config>> = Lazy::new(|| ArcSwap::from_pointee(Config
 /// Server role: primary or replica.
 #[derive(Clone, PartialEq, Serialize, Deserialize, Hash, std::cmp::Eq, Debug, Copy)]
 pub enum Role {
+    #[serde(alias="primary", alias="Primary")]
     Primary,
+    #[serde(alias="replica", alias="Replica")]
     Replica,
 }
 
@@ -202,17 +204,28 @@ impl Default for Pool {
     }
 }
 
+#[derive(Clone, PartialEq, Serialize, Deserialize, Debug, Hash, Eq)]
+pub struct ServerConfig {
+    pub host: String,
+    pub port: u16,
+    pub role: Role,
+}
+
 /// Shard configuration.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct Shard {
     pub database: String,
-    pub servers: Vec<(String, u16, String)>,
+    pub servers: Vec<ServerConfig>,
 }
 
 impl Default for Shard {
     fn default() -> Shard {
         Shard {
-            servers: vec![(String::from("localhost"), 5432, String::from("primary"))],
+            servers: vec![ServerConfig {
+                host: String::from("localhost"),
+                port: 5432,
+                role: Role::Primary,
+            }],
             database: String::from("postgres"),
         }
     }
@@ -538,22 +551,9 @@ pub async fn parse(path: &str) -> Result<(), Error> {
                 dup_check.insert(server);
 
                 // Check that we define only zero or one primary.
-                match server.2.as_ref() {
-                    "primary" => primary_count += 1,
+                match server.role {
+                    Role::Primary => primary_count += 1,
                     _ => (),
-                };
-
-                // Check role spelling.
-                match server.2.as_ref() {
-                    "primary" => (),
-                    "replica" => (),
-                    _ => {
-                        error!(
-                            "Shard {} server role must be either 'primary' or 'replica', got: '{}'",
-                            shard.0, server.2
-                        );
-                        return Err(Error::BadConfig);
-                    }
                 };
             }
 
@@ -617,12 +617,12 @@ mod test {
         assert_eq!(get_config().pools["simple_db"].users.len(), 1);
 
         assert_eq!(
-            get_config().pools["sharded_db"].shards["0"].servers[0].0,
+            get_config().pools["sharded_db"].shards["0"].servers[0].host,
             "127.0.0.1"
         );
         assert_eq!(
-            get_config().pools["sharded_db"].shards["1"].servers[0].2,
-            "primary"
+            get_config().pools["sharded_db"].shards["1"].servers[0].role,
+            Role::Primary
         );
         assert_eq!(
             get_config().pools["sharded_db"].shards["1"].database,
@@ -640,11 +640,11 @@ mod test {
         assert_eq!(get_config().pools["sharded_db"].default_role, "any");
 
         assert_eq!(
-            get_config().pools["simple_db"].shards["0"].servers[0].0,
+            get_config().pools["simple_db"].shards["0"].servers[0].host,
             "127.0.0.1"
         );
         assert_eq!(
-            get_config().pools["simple_db"].shards["0"].servers[0].1,
+            get_config().pools["simple_db"].shards["0"].servers[0].port,
             5432
         );
         assert_eq!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,7 +37,7 @@ extern crate tokio;
 extern crate tokio_rustls;
 extern crate toml;
 
-use log::{debug, error, info};
+use log::{error, info, warn};
 use parking_lot::Mutex;
 use pgcat::format_duration;
 use tokio::net::TcpListener;
@@ -279,7 +279,7 @@ async fn main() {
                                 }
                             }
 
-                            debug!("Client disconnected with error {:?}", err);
+                            warn!("Client disconnected with error {:?}", err);
                         }
                     };
                 });

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -143,21 +143,12 @@ impl ConnectionPool {
                     let mut replica_number = 0;
 
                     for server in shard.servers.iter() {
-                        let role = match server.2.as_ref() {
-                            "primary" => Role::Primary,
-                            "replica" => Role::Replica,
-                            _ => {
-                                error!("Config error: server role can be 'primary' or 'replica', have: '{}'. Defaulting to 'replica'.", server.2);
-                                Role::Replica
-                            }
-                        };
-
                         let address = Address {
                             id: address_id,
                             database: shard.database.clone(),
-                            host: server.0.clone(),
-                            port: server.1 as u16,
-                            role: role,
+                            host: server.host.clone(),
+                            port: server.port,
+                            role: server.role,
                             address_index,
                             replica_number,
                             shard: shard_idx.parse::<usize>().unwrap(),
@@ -168,7 +159,7 @@ impl ConnectionPool {
                         address_id += 1;
                         address_index += 1;
 
-                        if role == Role::Replica {
+                        if server.role == Role::Replica {
                             replica_number += 1;
                         }
 

--- a/src/query_router.rs
+++ b/src/query_router.rs
@@ -169,8 +169,8 @@ impl QueryRouter {
 
             Command::ShowShard => self.shard().to_string(),
             Command::ShowServerRole => match self.active_role {
-                Some(Role::Primary) => String::from("primary"),
-                Some(Role::Replica) => String::from("replica"),
+                Some(Role::Primary) => Role::Primary.to_string(),
+                Some(Role::Replica) => Role::Replica.to_string(),
                 None => {
                     if self.query_parser_enabled {
                         String::from("auto")


### PR DESCRIPTION
This change to use an enum to check the role gives us free spellchecking and validation.

Adds warning log when rolling back to give better idea of how often rollbacks/discards are happening

