### PR TITLE
Log failed client logins

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -1,6 +1,6 @@
 /// Handle clients by pretending to be a PostgreSQL server.
 use bytes::{Buf, BufMut, BytesMut};
-use log::{debug, error, info, trace};
+use log::{debug, error, info, trace, warn};
 use std::collections::HashMap;
 use std::time::Instant;
 use tokio::io::{split, AsyncReadExt, BufReader, ReadHalf, WriteHalf};
@@ -457,6 +457,8 @@ where
                         ),
                     )
                     .await?;
+
+                    warn!("Failed client login {{ username: {:?}, pool_name: {:?}, application_name: {:?} }}", pool_name.clone(), username.clone(), application_name.clone());
 
                     return Err(Error::ClientError);
                 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -436,7 +436,7 @@ where
             );
 
             if password_hash != password_response {
-                warn!("Invalid password {{ username: {:?}, pool_name: {:?}, application_name: {:?} }}", pool_name.clone(), username.clone(), application_name.clone());
+                warn!("Invalid password {{ username: {:?}, pool_name: {:?}, application_name: {:?} }}", pool_name, username, application_name);
                 wrong_password(&mut write, username).await?;
 
                 return Err(Error::ClientError);
@@ -458,7 +458,7 @@ where
                     )
                     .await?;
 
-                    warn!("Invalid pool name {{ username: {:?}, pool_name: {:?}, application_name: {:?} }}", pool_name.clone(), username.clone(), application_name.clone());
+                    warn!("Invalid pool name {{ username: {:?}, pool_name: {:?}, application_name: {:?} }}", pool_name, username, application_name);
                     return Err(Error::ClientError);
                 }
             };
@@ -467,7 +467,7 @@ where
             let password_hash = md5_hash_password(&username, &pool.settings.user.password, &salt);
 
             if password_hash != password_response {
-                warn!("Invalid password {{ username: {:?}, pool_name: {:?}, application_name: {:?} }}", pool_name.clone(), username.clone(), application_name.clone());
+                warn!("Invalid password {{ username: {:?}, pool_name: {:?}, application_name: {:?} }}", pool_name, username, application_name);
                 wrong_password(&mut write, username).await?;
 
                 return Err(Error::ClientError);

--- a/src/client.rs
+++ b/src/client.rs
@@ -436,7 +436,7 @@ where
             );
 
             if password_hash != password_response {
-                debug!("Password authentication failed");
+                warn!("Invalid password {{ username: {:?}, pool_name: {:?}, application_name: {:?} }}", pool_name.clone(), username.clone(), application_name.clone());
                 wrong_password(&mut write, username).await?;
 
                 return Err(Error::ClientError);
@@ -458,8 +458,7 @@ where
                     )
                     .await?;
 
-                    warn!("Failed client login {{ username: {:?}, pool_name: {:?}, application_name: {:?} }}", pool_name.clone(), username.clone(), application_name.clone());
-
+                    warn!("Invalid pool name {{ username: {:?}, pool_name: {:?}, application_name: {:?} }}", pool_name.clone(), username.clone(), application_name.clone());
                     return Err(Error::ClientError);
                 }
             };
@@ -468,7 +467,7 @@ where
             let password_hash = md5_hash_password(&username, &pool.settings.user.password, &salt);
 
             if password_hash != password_response {
-                debug!("Password authentication failed");
+                warn!("Invalid password {{ username: {:?}, pool_name: {:?}, application_name: {:?} }}", pool_name.clone(), username.clone(), application_name.clone());
                 wrong_password(&mut write, username).await?;
 
                 return Err(Error::ClientError);
@@ -660,6 +659,8 @@ where
                         ),
                     )
                     .await?;
+
+                    warn!("Invalid pool name {{ username: {:?}, pool_name: {:?}, application_name: {:?} }}", self.pool_name.clone(), self.username.clone(), self.application_name.clone());
                     return Err(Error::ClientError);
                 }
             };

--- a/src/client.rs
+++ b/src/client.rs
@@ -660,7 +660,7 @@ where
                     )
                     .await?;
 
-                    warn!("Invalid pool name {{ username: {:?}, pool_name: {:?}, application_name: {:?} }}", self.pool_name.clone(), self.username.clone(), self.application_name.clone());
+                    warn!("Invalid pool name {{ username: {:?}, pool_name: {:?}, application_name: {:?} }}", self.pool_name, self.username, self.application_name);
                     return Err(Error::ClientError);
                 }
             };


### PR DESCRIPTION
Currently the only place where there is a record of client login failures is in Pgcat's response to the client. We don't log that anywhere on the sever side.

This PR adds logging for that event and to bad pool name login.