### PR TITLE
Set client state to idle after error

### DIFF
--- a/src/stats.rs
+++ b/src/stats.rs
@@ -743,7 +743,7 @@ impl Collector {
                         Some(client_info) => {
                             client_info.state = ClientState::Idle;
                             client_info.error_count += stat.value as u64;
-                        },
+                        }
                         None => warn!("Got event {:?} for unregistered client", stat.name),
                     }
 
@@ -763,7 +763,7 @@ impl Collector {
                         Some(client_info) => {
                             client_info.state = ClientState::Idle;
                             client_info.error_count += stat.value as u64;
-                        },
+                        }
                         None => warn!("Got event {:?} for unregistered client", stat.name),
                     }
 

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -740,7 +740,10 @@ impl Collector {
                     address_id,
                 } => {
                     match client_states.get_mut(&client_id) {
-                        Some(client_info) => client_info.error_count += stat.value as u64,
+                        Some(client_info) => {
+                            client_info.state = ClientState::Idle;
+                            client_info.error_count += stat.value as u64;
+                        },
                         None => warn!("Got event {:?} for unregistered client", stat.name),
                     }
 
@@ -757,7 +760,10 @@ impl Collector {
                     address_id,
                 } => {
                     match client_states.get_mut(&client_id) {
-                        Some(client_info) => client_info.error_count += stat.value as u64,
+                        Some(client_info) => {
+                            client_info.state = ClientState::Idle;
+                            client_info.error_count += stat.value as u64;
+                        },
                         None => warn!("Got event {:?} for unregistered client", stat.name),
                     }
 

--- a/tests/ruby/admin_spec.rb
+++ b/tests/ruby/admin_spec.rb
@@ -147,7 +147,7 @@ describe "Admin" do
     end
 
     context "client fail to checkout connection from the pool" do
-      it "produces counts clients as idle" do
+      it "counts clients as idle" do
         new_configs = processes.pgcat.current_config
         new_configs["general"]["connect_timeout"] = 500
         new_configs["general"]["ban_time"] = 1


### PR DESCRIPTION
If clients fail to checkout a connection from the pool or lose a connection they had, we don't change the state of the client so it will be stuck in state `active` or `waiting`. This state is not persistent as the client state will be corrected the next time the client attempts to perform a query.

This PR fixes this by setting client state to `idle` after errors. It also adds tests that cover that case.  