### PR TITLE
Cleaner formatting for some logs

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -138,6 +138,8 @@ pub async fn client_entrypoint(
             // TLS is not configured, we cannot offer it.
             else {
                 // Rejecting client request for TLS.
+                debug!("Rejecting TLS request");
+
                 let mut no = BytesMut::new();
                 no.put_u8(b'N');
                 write_all(&mut stream, no).await?;

--- a/src/client.rs
+++ b/src/client.rs
@@ -436,7 +436,10 @@ where
             );
 
             if password_hash != password_response {
-                warn!("Invalid password {{ username: {:?}, pool_name: {:?}, application_name: {:?} }}", pool_name, username, application_name);
+                warn!(
+                    "[pool: {}][user: {}][application_name: {}] Invalid password",
+                    pool_name, username, application_name
+                );
                 wrong_password(&mut write, username).await?;
 
                 return Err(Error::ClientError);
@@ -458,7 +461,10 @@ where
                     )
                     .await?;
 
-                    warn!("Invalid pool name {{ username: {:?}, pool_name: {:?}, application_name: {:?} }}", pool_name, username, application_name);
+                    warn!(
+                        "[pool: {}][user: {}][application_name: {}] Pool does not exist",
+                        pool_name, username, application_name
+                    );
                     return Err(Error::ClientError);
                 }
             };
@@ -467,7 +473,10 @@ where
             let password_hash = md5_hash_password(&username, &pool.settings.user.password, &salt);
 
             if password_hash != password_response {
-                warn!("Invalid password {{ username: {:?}, pool_name: {:?}, application_name: {:?} }}", pool_name, username, application_name);
+                warn!(
+                    "[pool: {}][user: {}][application_name: {}] Invalid password",
+                    pool_name, username, application_name
+                );
                 wrong_password(&mut write, username).await?;
 
                 return Err(Error::ClientError);

--- a/src/config.rs
+++ b/src/config.rs
@@ -147,6 +147,16 @@ pub struct User {
     pub statement_timeout: u64,
 }
 
+impl std::fmt::Display for User {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(
+            f,
+            "[user: {}][pool_size: {}][statement_timeout: {}]",
+            self.username, self.pool_size, self.statement_timeout
+        )
+    }
+}
+
 impl Default for User {
     fn default() -> User {
         User {
@@ -168,6 +178,8 @@ pub struct General {
     pub port: i16,
 
     pub enable_prometheus_exporter: Option<bool>,
+
+    #[serde(default = "General::default_prometheus_exporter_port")]
     pub prometheus_exporter_port: i16,
 
     #[serde(default = "General::default_connect_timeout")]
@@ -201,6 +213,10 @@ impl General {
 
     fn default_port() -> i16 {
         5432
+    }
+
+    fn default_prometheus_exporter_port() -> i16 {
+        9930
     }
 
     fn default_connect_timeout() -> u64 {
@@ -257,11 +273,11 @@ pub enum PoolMode {
     Session,
 }
 
-impl ToString for PoolMode {
-    fn to_string(&self) -> String {
+impl std::fmt::Display for PoolMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match *self {
-            PoolMode::Transaction => "transaction".to_string(),
-            PoolMode::Session => "session".to_string(),
+            PoolMode::Transaction => write!(f, "transaction"),
+            PoolMode::Session => write!(f, "session"),
         }
     }
 }
@@ -271,6 +287,7 @@ pub struct Pool {
     #[serde(default = "Pool::default_pool_mode")]
     pub pool_mode: PoolMode,
 
+    #[serde(default = "Pool::default_default_role")]
     pub default_role: String,
 
     #[serde(default)] // False
@@ -282,7 +299,9 @@ pub struct Pool {
     #[serde(default = "General::default_connect_timeout")]
     pub connect_timeout: u64,
 
+    #[serde(default = "Pool::default_sharding_function")]
     pub sharding_function: String,
+
     pub shards: BTreeMap<String, Shard>,
     pub users: BTreeMap<String, User>,
 }
@@ -290,6 +309,14 @@ pub struct Pool {
 impl Pool {
     fn default_pool_mode() -> PoolMode {
         PoolMode::Transaction
+    }
+
+    fn default_sharding_function() -> String {
+        "pg_bigint_hash".to_string()
+    }
+
+    fn default_default_role() -> String {
+        "any".to_string()
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -29,15 +29,6 @@ pub enum Role {
     Replica,
 }
 
-impl ToString for Role {
-    fn to_string(&self) -> String {
-        match *self {
-            Role::Primary => "primary".to_string(),
-            Role::Replica => "replica".to_string(),
-        }
-    }
-}
-
 impl PartialEq<Option<Role>> for Role {
     fn eq(&self, other: &Option<Role>) -> bool {
         match other {
@@ -52,6 +43,15 @@ impl PartialEq<Role> for Option<Role> {
         match *self {
             None => true,
             Some(role) => role == *other,
+        }
+    }
+}
+
+impl std::fmt::Display for Role {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match *self {
+            Role::Primary => write!(f, "primary"),
+            Role::Replica => write!(f, "replica"),
         }
     }
 }
@@ -88,6 +88,22 @@ pub struct Address {
 
     /// The name of this pool (i.e. database name visible to the client).
     pub pool_name: String,
+}
+
+impl std::fmt::Display for Address {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(
+            f,
+            "[pool: {}][user: {}][host: {}][port: {}][db: {}][shard: {}][role: {}]",
+            self.pool_name,
+            self.username,
+            self.host,
+            self.port,
+            self.database,
+            self.shard,
+            self.role,
+        )
+    }
 }
 
 impl Default for Address {

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,7 +37,7 @@ extern crate tokio;
 extern crate tokio_rustls;
 extern crate toml;
 
-use log::{error, info, warn};
+use log::{error, info, trace, warn};
 use parking_lot::Mutex;
 use pgcat::format_duration;
 use tokio::net::TcpListener;
@@ -242,6 +242,8 @@ async fn main() {
                         continue;
                     }
                 };
+
+                trace!("Connection request from {:?}", addr);
 
                 let shutdown_rx = shutdown_tx.subscribe();
                 let drain_tx = drain_tx.clone();

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -558,7 +558,7 @@ impl ManageConnection for ServerPool {
 
     /// Attempts to create a new connection.
     async fn connect(&self) -> Result<Self::Connection, Self::Error> {
-        info!("Creating a new server connection {:?}", self.address);
+        info!("{} creating a new server connection", self.address);
         let server_id = rand::random::<i32>();
 
         self.stats.server_register(

--- a/src/server.rs
+++ b/src/server.rs
@@ -546,7 +546,7 @@ impl Server {
 
     /// Indicate that this server connection cannot be re-used and must be discarded.
     pub fn mark_bad(&mut self) {
-        error!("Server {:?} marked bad", self.address);
+        error!("{} marked bad", self.address);
         self.bad = true;
     }
 
@@ -673,7 +673,7 @@ impl Drop for Server {
         let duration = now - self.connected_at;
 
         info!(
-            "Server connection closed {:?}, session duration: {}",
+            "{} server connection closed, session duration: {}",
             self.address,
             crate::format_duration(&duration)
         );

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -52,6 +52,7 @@ pub enum ClientState {
     Waiting,
     Active,
 }
+
 impl std::fmt::Display for ClientState {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match *self {
@@ -70,6 +71,7 @@ pub enum ServerState {
     Tested,
     Idle,
 }
+
 impl std::fmt::Display for ServerState {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match *self {
@@ -250,20 +252,21 @@ impl Reporter {
 
     /// Send statistics to the task keeping track of stats.
     fn send(&self, event: Event) {
-        let name = event.name.clone();
         let result = self.tx.try_send(event.clone());
 
         match result {
             Ok(_) => trace!(
-                "{:?} event reported successfully, capacity: {} {:?}",
-                name,
+                "{:?} event reported successfully, capacity: {}, value: {}",
+                event.name,
                 self.tx.capacity(),
-                event
+                event.value
             ),
 
             Err(err) => match err {
-                TrySendError::Full { .. } => error!("{:?} event dropped, buffer full", name),
-                TrySendError::Closed { .. } => error!("{:?} event dropped, channel closed", name),
+                TrySendError::Full { .. } => error!("{:?} event dropped, buffer full", event.name),
+                TrySendError::Closed { .. } => {
+                    error!("{:?} event dropped, channel closed", event.name)
+                }
             },
         };
     }


### PR DESCRIPTION
1. Cleaner logs
2. Add more defaults to config
3. Remove unnecessary `clone`
4. Added debug log line for TLS rejection because I was confused by warn messages locally - realized this was because I didn't have TLS certificates setup.