### PR TITLE
Replace a few types with more developer-friendly names

### DIFF
--- a/src/admin.rs
+++ b/src/admin.rs
@@ -215,16 +215,16 @@ where
 
     let mut res = BytesMut::new();
     res.put(row_description(&columns));
-    for ((pool_name, username), pool) in get_all_pools() {
+    for (user_pool, pool) in get_all_pools() {
         let def = HashMap::default();
         let pool_stats = all_pool_stats
-            .get(&(pool_name.clone(), username.clone()))
+            .get(&(user_pool.db.clone(), user_pool.user.clone()))
             .unwrap_or(&def);
 
         let pool_config = &pool.settings;
         let mut row = vec![
-            pool_name.clone(),
-            username.clone(),
+            user_pool.db.clone(),
+            user_pool.user.clone(),
             pool_config.pool_mode.to_string(),
         ];
         for column in &columns[3..columns.len()] {
@@ -420,7 +420,7 @@ where
     let mut res = BytesMut::new();
     res.put(row_description(&columns));
 
-    for ((db, username), pool) in get_all_pools() {
+    for (user_pool, pool) in get_all_pools() {
         for shard in 0..pool.shards() {
             for server in 0..pool.servers(shard) {
                 let address = pool.address(shard, server);
@@ -429,7 +429,7 @@ where
                     None => HashMap::new(),
                 };
 
-                let mut row = vec![address.name(), db.clone(), username.clone()];
+                let mut row = vec![address.name(), user_pool.db.clone(), user_pool.user.clone()];
                 for column in &columns[3..] {
                     row.push(stats.get(column.0).unwrap_or(&0).to_string());
                 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -446,7 +446,7 @@ where
         }
         // Authenticate normal user.
         else {
-            let pool = match get_pool(pool_name.clone(), username.clone()) {
+            let pool = match get_pool(&pool_name, &username) {
                 Some(pool) => pool,
                 None => {
                     error_response(
@@ -648,7 +648,7 @@ where
             // Get a pool instance referenced by the most up-to-date
             // pointer. This ensures we always read the latest config
             // when starting a query.
-            let pool = match get_pool(self.pool_name.clone(), self.username.clone()) {
+            let pool = match get_pool(&self.pool_name, &self.username) {
                 Some(pool) => pool,
                 None => {
                     error_response(

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -521,11 +521,11 @@ impl Collector {
                 tokio::time::interval(tokio::time::Duration::from_millis(STAT_PERIOD / 15));
             loop {
                 interval.tick().await;
-                for ((pool_name, username), _pool) in get_all_pools() {
+                for (user_pool, _) in get_all_pools() {
                     let _ = tx.try_send(Event {
                         name: EventName::UpdateStats {
-                            pool_name,
-                            username,
+                            pool_name: user_pool.db,
+                            username: user_pool.user,
                         },
                         value: 0,
                     });


### PR DESCRIPTION
Replace a couple "hardcoded" types with more expressive types so it's easier for newcomers to read the code and understand what's going on.