### PR TITLE
Force health check after unbanning and make is_banned more light weight

### DIFF
--- a/src/admin.rs
+++ b/src/admin.rs
@@ -277,7 +277,7 @@ where
             for server in 0..pool.servers(shard) {
                 let address = pool.address(shard, server);
                 let pool_state = pool.pool_state(shard, server);
-                let banned = pool.is_banned(address, Some(address.role));
+                let banned = pool.is_banned(address);
 
                 res.put(data_row(&vec![
                     address.name(),                         // name


### PR DESCRIPTION
A banned instance will only be banned for the duration of the ban_time setting. If an instance experiences issues longer than the ban time and shorter than the health check delay, it will return to the pool of available instances and clients will connect to the bad replica.

This PR makes the is_banned function more lightweight (it's used by the admin db) and forces health check after unbanning an instance