### PR TITLE
Don't send discard all when state is changed in transaction

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -601,7 +601,7 @@ where
             // in case the client is sending some custom protocol messages, e.g.
             // SET SHARDING KEY TO 'bigint';
 
-            let mut message = tokio::select! {
+            let message = tokio::select! {
                 _ = self.shutdown.recv() => {
                     if !self.admin {
                         error_response_terminal(

--- a/src/client.rs
+++ b/src/client.rs
@@ -827,7 +827,7 @@ where
 
                 // Safe to unwrap because we know this message has a certain length and has the code
                 // This reads the first byte without advancing the internal pointer and mutating the bytes
-                let code = *message.get(0).unwrap() as char;
+                let code = *message.get(0).unwrap_or(&('$' as u8)) as char;
 
                 trace!("Message: {}", code);
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -827,7 +827,7 @@ where
 
                 // Safe to unwrap because we know this message has a certain length and has the code
                 // This reads the first byte without advancing the internal pointer and mutating the bytes
-                let code = *message.get(0).unwrap_or(&('$' as u8)) as char;
+                let code = *message.get(0).unwrap() as char;
 
                 trace!("Message: {}", code);
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -827,7 +827,7 @@ where
                 trace!("Message: {}", code);
 
                 match code {
-                    // ReadyForQuery
+                    // Query
                     'Q' => {
                         debug!("Sending query to server");
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -822,6 +822,7 @@ where
                 // parse it below to figure out what to do with it.
 
                 // Safe to unwrap because we know this message has a certain length and has the code
+                // This reads the first byte without advancing the internal pointer and mutating the bytes
                 let code = *message.get(0).unwrap() as char;
 
                 trace!("Message: {}", code);
@@ -885,7 +886,6 @@ where
 
                         self.buffer.put(&message[..]);
 
-                        // Clone after freeze does not allocate
                         let first_message_code = (*self.buffer.get(0).unwrap_or(&0)) as char;
 
                         // Almost certainly true

--- a/src/server.rs
+++ b/src/server.rs
@@ -450,6 +450,11 @@ impl Server {
 
                 // CommandComplete
                 'C' => {
+
+                    if self.in_transaction {
+                        continue;
+                    }
+
                     let mut command_tag = String::new();
                     match message.reader().read_to_string(&mut command_tag) {
                         Ok(_) => {

--- a/src/server.rs
+++ b/src/server.rs
@@ -462,11 +462,10 @@ impl Server {
                                     // No great way to differentiate between set and set local
                                     // As a result, we will miss cases when set statements are used in transactions
                                     // This will reduce amount of discard statements sent
-                                    if self.in_transaction {
-                                        continue;
+                                    if !self.in_transaction {
+                                        debug!("Server connection marked for clean up");
+                                        self.needs_cleanup = true;
                                     }
-                                    debug!("Server connection marked for clean up");
-                                    self.needs_cleanup = true;
                                 }
                                 "PREPARE\0" => {
                                     debug!("Server connection marked for clean up");

--- a/src/server.rs
+++ b/src/server.rs
@@ -461,6 +461,7 @@ impl Server {
                                     // We don't detect set statements in transactions
                                     // No great way to differentiate between set and set local
                                     // As a result, we will miss cases when set statements are used in transactions
+                                    // This will reduce amount of discard statements sent
                                     if self.in_transaction {
                                         continue;
                                     }

--- a/src/server.rs
+++ b/src/server.rs
@@ -606,7 +606,7 @@ impl Server {
             self.query("ROLLBACK").await?;
         }
 
-        // Client disconnected but it perfromed session-altering operations such as
+        // Client disconnected but it performed session-altering operations such as
         // SET statement_timeout to 1 or create a prepared statement. We clear that
         // to avoid leaking state between clients. For performance reasons we only
         // send `DISCARD ALL` if we think the session is altered instead of just sending

--- a/tests/ruby/misc_spec.rb
+++ b/tests/ruby/misc_spec.rb
@@ -202,6 +202,16 @@ describe "Miscellaneous" do
           conn.close
         end 
         expect(processes.primary.count_query("DISCARD ALL")).to eq(0)
+
+        10.times do
+          conn = PG::connect(processes.pgcat.connection_string("sharded_db", "sharding_user"))
+          conn.async_exec("SET SERVER ROLE to 'primary'")
+          conn.async_exec("BEGIN")
+          conn.async_exec("SET LOCAL statement_timeout to 1000")
+          conn.async_exec("COMMIT")
+          conn.close
+        end 
+        expect(processes.primary.count_query("DISCARD ALL")).to eq(0)
       end
     end
   end

--- a/tests/ruby/misc_spec.rb
+++ b/tests/ruby/misc_spec.rb
@@ -189,5 +189,20 @@ describe "Miscellaneous" do
         expect(processes.primary.count_query("DISCARD ALL")).to eq(10)
       end
     end
+    
+    context "transaction mode with transactions" do
+      let(:processes) { Helpers::Pgcat.single_shard_setup("sharded_db", 5, "transaction") }
+      it "Does not clear set statement state when declared in a transaction" do
+        10.time do
+          conn = PG::connect(processes.pgcat.connection_string("sharded_db", "sharding_user"))
+          conn.async_exec("SET SERVER ROLE to 'primary'")
+          conn.async_exec("BEGIN")
+          conn.async_exec("SET statement_timeout to 1000")
+          conn.async_exec("COMMIT")
+          conn.close
+        end 
+        expect(processes.primary.count_query("DISCARD ALL")).to eq(0)
+      end
+    end
   end
 end

--- a/tests/ruby/misc_spec.rb
+++ b/tests/ruby/misc_spec.rb
@@ -193,7 +193,7 @@ describe "Miscellaneous" do
     context "transaction mode with transactions" do
       let(:processes) { Helpers::Pgcat.single_shard_setup("sharded_db", 5, "transaction") }
       it "Does not clear set statement state when declared in a transaction" do
-        10.time do
+        10.times do
           conn = PG::connect(processes.pgcat.connection_string("sharded_db", "sharding_user"))
           conn.async_exec("SET SERVER ROLE to 'primary'")
           conn.async_exec("BEGIN")


### PR DESCRIPTION
If a set statement is sent in a transaction then we shouldn't try to send the `DISCARD ALL` statement

Gets rid of two message clones that are almost always hit