### PR TITLE
A bit faster get_pool

### DIFF
--- a/src/pool.rs
+++ b/src/pool.rs
@@ -633,7 +633,7 @@ impl ManageConnection for ServerPool {
 
 /// Get the connection pool
 pub fn get_pool(db: &str, user: &str) -> Option<ConnectionPool> {
-    match (*(*POOLS.load())).get(&PoolIdentifier { db: db.to_string(), user: user.to_string() }) {
+    match (*(*POOLS.load())).get(&PoolIdentifier::new(db, user)) {
         Some(pool) => Some(pool.clone()),
         None => None,
     }

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -633,7 +633,7 @@ impl ManageConnection for ServerPool {
 
 /// Get the connection pool
 pub fn get_pool(db: &str, user: &str) -> Option<ConnectionPool> {
-    match get_all_pools().get(&PoolIdentifier::new(&db, &user)) {
+    match (*(*POOLS.load())).get(&PoolIdentifier { db: db.to_string(), user: user.to_string() }) {
         Some(pool) => Some(pool.clone()),
         None => None,
     }


### PR DESCRIPTION
`get_pool` method internally calls `get_all_pools` and then operates on the returned HashMap. 
The problem with this is that `get_all_pools` clones the HashMap that contains all pools information which makes the `get_pool` operation speed depend on how many pools we have configured. 

We change this a bit by cloning the target pool directly from the global `POOLS` object. 

The `get_pool` method is used on the client codepath so we want to make it as cheap as possible.

Flamegraph before change
<img width="1728" alt="Screen Shot 2022-10-08 at 9 27 06 AM" src="https://user-images.githubusercontent.com/202050/194713010-1b22f830-3fee-4d54-8db0-c3735717f82b.png">

Flamegraph after the change
<img width="1723" alt="Screen Shot 2022-10-08 at 9 26 36 AM" src="https://user-images.githubusercontent.com/202050/194713011-8f7f3ac6-8a2d-40d6-80e0-e92f212b3d4a.png">

Flamegraph before the change zoomed in on `get_pool`
<img width="1718" alt="Screen Shot 2022-10-08 at 9 40 26 AM" src="https://user-images.githubusercontent.com/202050/194713008-b8726744-0c74-4fa9-9c74-ff69955aab11.png">
