### PR TITLE
Automatic sharding: part one of many

### DIFF
--- a/pgcat.toml
+++ b/pgcat.toml
@@ -83,6 +83,9 @@ primary_reads_enabled = true
 #
 sharding_function = "pg_bigint_hash"
 
+# Automatically parse this from queries and route queries to the right shard!
+automatic_sharding_key = "id"
+
 # Credentials for users that may connect to this cluster
 [pools.sharded_db.users.0]
 username = "sharding_user"

--- a/src/client.rs
+++ b/src/client.rs
@@ -672,7 +672,7 @@ where
                 // Normal query, not a custom command.
                 None => {
                     if query_router.query_parser_enabled() {
-                        query_router.infer_role(message.clone());
+                        query_router.infer(message.clone());
                     }
                 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -267,6 +267,10 @@ pub struct Pool {
     pub connect_timeout: Option<u64>,
 
     pub sharding_function: ShardingFunction,
+
+    #[serde(default = "Pool::default_automatic_sharding_key")]
+    pub automatic_sharding_key: Option<String>,
+
     pub shards: BTreeMap<String, Shard>,
     pub users: BTreeMap<String, User>,
 }
@@ -274,6 +278,10 @@ pub struct Pool {
 impl Pool {
     pub fn default_pool_mode() -> PoolMode {
         PoolMode::Transaction
+    }
+
+    pub fn default_automatic_sharding_key() -> Option<String> {
+        None
     }
 
     pub fn validate(&self) -> Result<(), Error> {
@@ -318,6 +326,7 @@ impl Default for Pool {
             query_parser_enabled: false,
             primary_reads_enabled: false,
             sharding_function: ShardingFunction::PgBigintHash,
+            automatic_sharding_key: None,
             connect_timeout: None,
         }
     }

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -79,6 +79,9 @@ pub struct PoolSettings {
 
     // Sharding function.
     pub sharding_function: ShardingFunction,
+
+    // Sharding key
+    pub automatic_sharding_key: Option<String>,
 }
 
 impl Default for PoolSettings {
@@ -91,6 +94,7 @@ impl Default for PoolSettings {
             query_parser_enabled: false,
             primary_reads_enabled: true,
             sharding_function: ShardingFunction::PgBigintHash,
+            automatic_sharding_key: None,
         }
     }
 }
@@ -254,6 +258,7 @@ impl ConnectionPool {
                         query_parser_enabled: pool_config.query_parser_enabled.clone(),
                         primary_reads_enabled: pool_config.primary_reads_enabled,
                         sharding_function: pool_config.sharding_function,
+                        automatic_sharding_key: pool_config.automatic_sharding_key.clone(),
                     },
                 };
 


### PR DESCRIPTION
You'll note a lot of TODOs here.

If you have a simple `Q` query, this should be able to get the sharding key out of it and route the query to the right shard automatically. Supports basic SQL, I think more advanced, e.g. subqueries, might need more work.

Long list of TODOs, but most important ones:

- support prepared statements
- support subqueries
- support `WITH` contexts for analytics use cases
- support parsing the sharding key when it's fully qualified, e.g `table_name.sharding_key` (should be pretty easy)

Notable limitations:
- we can't infer the sharding key if it's not explicitly specified, so queries like `SELECT * FROM t WHERE sharding_key IN (SELECT id FROM some_other_table);` won't work.
- surely many more