### PR TITLE
Adds configuration for logging connections and removes get_config from entrypoint

### DIFF
--- a/.circleci/pgcat.toml
+++ b/.circleci/pgcat.toml
@@ -32,6 +32,12 @@ shutdown_timeout = 5000
 # For how long to ban a server if it fails a health check (seconds).
 ban_time = 60 # Seconds
 
+# If we should log client connections
+log_client_connections = false
+
+# If we should log client disconnections
+log_client_disconnections = false
+
 # Reload config automatically if it changes.
 autoreload = true
 

--- a/examples/docker/pgcat.toml
+++ b/examples/docker/pgcat.toml
@@ -32,6 +32,12 @@ shutdown_timeout = 60000
 # For how long to ban a server if it fails a health check (seconds).
 ban_time = 60 # seconds
 
+# If we should log client connections
+log_client_connections = false
+
+# If we should log client disconnections
+log_client_disconnections = false
+
 # Reload config automatically if it changes.
 autoreload = false
 

--- a/pgcat.toml
+++ b/pgcat.toml
@@ -32,6 +32,12 @@ shutdown_timeout = 60000
 # For how long to ban a server if it fails a health check (seconds).
 ban_time = 60 # seconds
 
+# If we should log client connections
+log_client_connections = false
+
+# If we should log client disconnections
+log_client_disconnections = false
+
 # Reload config automatically if it changes.
 autoreload = false
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -196,8 +196,6 @@ pub async fn client_entrypoint(
 
         // Client wants to use plain connection without encryption.
         Ok((ClientConnectionType::Startup, bytes)) => {
-            let config = get_config();
-
             let (read, write) = split(stream);
 
             // Continue with regular startup.
@@ -213,7 +211,7 @@ pub async fn client_entrypoint(
             .await
             {
                 Ok(mut client) => {
-                    if config.general.log_connections {
+                    if log_connections {
                         info!("Client {:?} connected (plain)", addr);
                     } else {
                         debug!("Client {:?} connected (plain)", addr);

--- a/src/client.rs
+++ b/src/client.rs
@@ -99,7 +99,7 @@ pub async fn client_entrypoint(
     drain: Sender<i32>,
     admin_only: bool,
     tls_certificate: Option<String>,
-    log_connections: bool,
+    log_client_connections: bool,
 ) -> Result<(), Error> {
     // Figure out if the client wants TLS or not.
     let addr = stream.peer_addr().unwrap();
@@ -118,7 +118,7 @@ pub async fn client_entrypoint(
                 // Negotiate TLS.
                 match startup_tls(stream, client_server_map, shutdown, admin_only).await {
                     Ok(mut client) => {
-                        if log_connections {
+                        if log_client_connections {
                             info!("Client {:?} connected (TLS)", addr);
                         } else {
                             debug!("Client {:?} connected (TLS)", addr);
@@ -166,7 +166,7 @@ pub async fn client_entrypoint(
                         .await
                         {
                             Ok(mut client) => {
-                                if log_connections {
+                                if log_client_connections {
                                     info!("Client {:?} connected (plain)", addr);
                                 } else {
                                     debug!("Client {:?} connected (plain)", addr);
@@ -211,7 +211,7 @@ pub async fn client_entrypoint(
             .await
             {
                 Ok(mut client) => {
-                    if log_connections {
+                    if log_client_connections {
                         info!("Client {:?} connected (plain)", addr);
                     } else {
                         debug!("Client {:?} connected (plain)", addr);

--- a/src/config.rs
+++ b/src/config.rs
@@ -157,6 +157,12 @@ pub struct General {
     #[serde(default = "General::default_connect_timeout")]
     pub connect_timeout: u64,
 
+    #[serde(default)] // False
+    pub log_client_connections: bool,
+
+    #[serde(default)] // False
+    pub log_client_disconnections: bool,
+
     #[serde(default = "General::default_shutdown_timeout")]
     pub shutdown_timeout: u64,
 
@@ -168,12 +174,6 @@ pub struct General {
 
     #[serde(default = "General::default_ban_time")]
     pub ban_time: i64,
-
-    #[serde(default)] // False
-    pub log_connections: bool,
-
-    #[serde(default)] // False
-    pub log_disconnections: bool,
 
     #[serde(default)] // False
     pub autoreload: bool,
@@ -226,8 +226,8 @@ impl Default for General {
             healthcheck_timeout: Self::default_healthcheck_timeout(),
             healthcheck_delay: Self::default_healthcheck_delay(),
             ban_time: Self::default_ban_time(),
-            log_connections: false,
-            log_disconnections: false,
+            log_client_connections: false,
+            log_client_disconnections: false,
             autoreload: false,
             tls_certificate: None,
             tls_private_key: None,
@@ -525,8 +525,11 @@ impl Config {
             self.general.healthcheck_timeout
         );
         info!("Connection timeout: {}ms", self.general.connect_timeout);
-        info!("Log connections: {}", self.general.log_connections);
-        info!("Log disconnections: {}", self.general.log_disconnections);
+        info!("Log connections: {}", self.general.log_client_connections);
+        info!(
+            "Log disconnections: {}",
+            self.general.log_client_disconnections
+        );
         info!("Shutdown timeout: {}ms", self.general.shutdown_timeout);
         info!("Healthcheck delay: {}ms", self.general.healthcheck_delay);
         match self.general.tls_certificate.clone() {

--- a/src/config.rs
+++ b/src/config.rs
@@ -525,7 +525,10 @@ impl Config {
             self.general.healthcheck_timeout
         );
         info!("Connection timeout: {}ms", self.general.connect_timeout);
-        info!("Log client connections: {}", self.general.log_client_connections);
+        info!(
+            "Log client connections: {}",
+            self.general.log_client_connections
+        );
         info!(
             "Log client disconnections: {}",
             self.general.log_client_disconnections

--- a/src/config.rs
+++ b/src/config.rs
@@ -525,9 +525,9 @@ impl Config {
             self.general.healthcheck_timeout
         );
         info!("Connection timeout: {}ms", self.general.connect_timeout);
-        info!("Log connections: {}", self.general.log_client_connections);
+        info!("Log client connections: {}", self.general.log_client_connections);
         info!(
-            "Log disconnections: {}",
+            "Log client disconnections: {}",
             self.general.log_client_disconnections
         );
         info!("Shutdown timeout: {}ms", self.general.shutdown_timeout);

--- a/src/config.rs
+++ b/src/config.rs
@@ -170,6 +170,12 @@ pub struct General {
     pub ban_time: i64,
 
     #[serde(default)] // False
+    pub log_connections: bool,
+
+    #[serde(default)] // False
+    pub log_disconnections: bool,
+
+    #[serde(default)] // False
     pub autoreload: bool,
 
     pub tls_certificate: Option<String>,
@@ -220,6 +226,8 @@ impl Default for General {
             healthcheck_timeout: Self::default_healthcheck_timeout(),
             healthcheck_delay: Self::default_healthcheck_delay(),
             ban_time: Self::default_ban_time(),
+            log_connections: false,
+            log_disconnections: false,
             autoreload: false,
             tls_certificate: None,
             tls_private_key: None,
@@ -517,6 +525,8 @@ impl Config {
             self.general.healthcheck_timeout
         );
         info!("Connection timeout: {}ms", self.general.connect_timeout);
+        info!("Log connections: {}", self.general.log_connections);
+        info!("Log disconnections: {}", self.general.log_disconnections);
         info!("Shutdown timeout: {}ms", self.general.shutdown_timeout);
         info!("Healthcheck delay: {}ms", self.general.healthcheck_delay);
         match self.general.tls_certificate.clone() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,7 +44,7 @@ use jemallocator::Jemalloc;
 #[global_allocator]
 static GLOBAL: Jemalloc = Jemalloc;
 
-use log::{error, info, warn};
+use log::{debug, error, info, warn};
 use parking_lot::Mutex;
 use pgcat::format_duration;
 use tokio::net::TcpListener;
@@ -247,6 +247,8 @@ async fn main() {
                 let drain_tx = drain_tx.clone();
                 let client_server_map = client_server_map.clone();
 
+                let tls_certificate = config.general.tls_certificate.clone();
+
                 tokio::task::spawn(async move {
                     let start = chrono::offset::Utc::now().naive_utc();
 
@@ -256,6 +258,8 @@ async fn main() {
                         shutdown_rx,
                         drain_tx,
                         admin_only,
+                        tls_certificate.clone(),
+                        config.general.log_connections,
                     )
                     .await
                     {
@@ -263,11 +267,19 @@ async fn main() {
 
                             let duration = chrono::offset::Utc::now().naive_utc() - start;
 
-                            info!(
-                                "Client {:?} disconnected, session duration: {}",
-                                addr,
-                                format_duration(&duration)
-                            );
+                            if config.general.log_disconnections {
+                                info!(
+                                    "Client {:?} disconnected, session duration: {}",
+                                    addr,
+                                    format_duration(&duration)
+                                );
+                            } else {
+                                debug!(
+                                    "Client {:?} disconnected, session duration: {}",
+                                    addr,
+                                    format_duration(&duration)
+                                );
+                            }
                         }
 
                         Err(err) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -259,7 +259,7 @@ async fn main() {
                         drain_tx,
                         admin_only,
                         tls_certificate.clone(),
-                        config.general.log_connections,
+                        config.general.log_client_connections,
                     )
                     .await
                     {
@@ -267,7 +267,7 @@ async fn main() {
 
                             let duration = chrono::offset::Utc::now().naive_utc() - start;
 
-                            if config.general.log_disconnections {
+                            if config.general.log_client_disconnections {
                                 info!(
                                     "Client {:?} disconnected, session duration: {}",
                                     addr,


### PR DESCRIPTION
This change adds a configuration to configure wether to log connections and disconnections which can be extremely noisy.
 
`get_config` can be expensive when called repeatedly and was being called in the client entrypoint. It is now moved outside the function makes the log_connections and tls_certificate configurations static