### PR TITLE
Move ClientBadStartup error log to debug

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -44,7 +44,7 @@ use jemallocator::Jemalloc;
 #[global_allocator]
 static GLOBAL: Jemalloc = Jemalloc;
 
-use log::{error, info, warn};
+use log::{debug, error, info, warn};
 use parking_lot::Mutex;
 use pgcat::format_duration;
 use tokio::net::TcpListener;
@@ -271,7 +271,11 @@ async fn main() {
                         }
 
                         Err(err) => {
-                            warn!("Client disconnected with error {:?}", err);
+                            match err {
+                                errors::Error::ClientBadStartup => debug!("Client disconnected with error {:?}", err),
+                                _ => warn!("Client disconnected with error {:?}", err),
+                            }
+
                         }
                     };
                 });


### PR DESCRIPTION
Healthchecks to the pgcat process which don't attempt to use the postgres protocol often present themselves as ClientBadStartup logs which can become extremely noisy. This log makes up the majority of our logging for pgcat due to aws healthchecks. Moving this to debug reduces this noise