### PR TITLE
Allow setting `idle_timeout` for server connections.

### DIFF
--- a/pgcat.toml
+++ b/pgcat.toml
@@ -20,6 +20,9 @@ prometheus_exporter_port = 9930
 # How long to wait before aborting a server connection (ms).
 connect_timeout = 5000
 
+# How long an idle connection with a server is left open (ms).
+idle_timeout = 30000
+
 # How much time to give the health check query to return with a result (ms).
 healthcheck_timeout = 1000
 
@@ -91,6 +94,9 @@ sharding_function = "pg_bigint_hash"
 
 # Automatically parse this from queries and route queries to the right shard!
 automatic_sharding_key = "id"
+
+# Idle timeout can be overwritten in the pool
+idle_timeout = 40000
 
 # Credentials for users that may connect to this cluster
 [pools.sharded_db.users.0]

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -224,9 +224,15 @@ impl ConnectionPool {
                             None => config.general.connect_timeout,
                         };
 
+                        let idle_timeout = match pool_config.idle_timeout {
+                            Some(idle_timeout) => idle_timeout,
+                            None => config.general.idle_timeout,
+                        };
+
                         let pool = Pool::builder()
                             .max_size(user.pool_size)
                             .connection_timeout(std::time::Duration::from_millis(connect_timeout))
+                            .idle_timeout(Some(std::time::Duration::from_millis(idle_timeout)))
                             .test_on_check_out(false)
                             .build(manager)
                             .await


### PR DESCRIPTION
In postgres, you can specify an `idle_session_timeout` which will close sessions idling for that amount of time. If a session is closed because of a timeout, PgCat will erroneously mark the server as unhealthy as the next health check will return an error because the connection was drop, if no health check is to be executed, it will simply fail trying to send the query to the server for the same reason, the conn was drop.

Given that bb8 allows configuring an idle_timeout for pools, it would be nice to allow setting this parameter in the config file, this way you can set it to something shorter than the server one. Also, server pool will be kept smaller in moments of less traffic. Actually, currently this value is set as its default in bb8, which is 10 minutes.

This change allows setting the parameter using the config file. It can be set both globally and per pool. When creating the pool, if the pool don't have it defined, global value is used.