### PR TITLE
Buffer copy data messages

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -510,9 +510,9 @@ impl Server {
                     break;
                 }
 
-                // CopyData: we are not buffering this one because there will be many more
-                // and we don't know how big this packet could be, best not to take a risk.
+                // CopyData
                 'd' => {
+                    // Don't flush yet, buffer until we reach limit
                     if self.buffer.len() >= 8196 {
                         break;
                     }

--- a/src/server.rs
+++ b/src/server.rs
@@ -512,7 +512,11 @@ impl Server {
 
                 // CopyData: we are not buffering this one because there will be many more
                 // and we don't know how big this packet could be, best not to take a risk.
-                'd' => break,
+                'd' => {
+                    if self.buffer.len() >= 8196 {
+                        break;
+                    }
+                }
 
                 // CopyDone
                 // Buffer until ReadyForQuery shows up, so don't exit the loop yet.


### PR DESCRIPTION
We currently buffer DataRow messages but not CopyData messages. We've observed CPU spikes in high COPY workloads. This may be attributed to the large number of SYS calls required to send each CopyData messages individually. This PR makes CopyData messages follow the same pattern as DataRow to buffer and reduce SYS calls