### PR TITLE
Allow server to be offline during validation

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -504,7 +504,7 @@ where
 
             let transaction_mode = pool.settings.pool_mode == PoolMode::Transaction;
 
-            (transaction_mode, pool.server_info())
+            (transaction_mode, pool.server_info().await?)
         };
 
         debug!("Password authentication successful");


### PR DESCRIPTION
If a server is offline during startup or a config reload, instead of failing, we will log the error. Then, when a client tries to connec to a particular pool, pgcat will attempt to connect to the upstream database server and obtain the server info params before passing them to the client. These server info params will then be cached so the next client will not need to wait for pgcat to connect to the upstream database again. These parameters are warmed or re-warmed during a reload.

This resolves https://github.com/levkk/pgcat/issues/254 .