### PR TITLE
Write messages directly onto message buffer instead of allocating on own buffer

### DIFF
--- a/src/messages.rs
+++ b/src/messages.rs
@@ -458,7 +458,7 @@ where
     }
 }
 
-// Write all the data in the buffer to the TcpStream, write owned half (see mpsc).
+/// Write all the data in the buffer to the TcpStream, write owned half (see mpsc).
 pub async fn write_all_half<S>(stream: &mut S, buf: BytesMut) -> Result<(), Error>
 where
     S: tokio::io::AsyncWrite + std::marker::Unpin,

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -503,7 +503,8 @@ where
     match stream
         .read_exact(
             &mut bytes[mem::size_of::<u8>() + mem::size_of::<i32>()
-                ..mem::size_of::<u8>() + mem::size_of::<i32>() + len as usize - mem::size_of::<i32>()],
+                ..mem::size_of::<u8>() + mem::size_of::<i32>() + len as usize
+                    - mem::size_of::<i32>()],
         )
         .await
     {

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -458,7 +458,7 @@ where
     }
 }
 
-/// Write all the data in the buffer to the TcpStream, write owned half (see mpsc).
+// Write all the data in the buffer to the TcpStream, write owned half (see mpsc).
 pub async fn write_all_half<S>(stream: &mut S, buf: BytesMut) -> Result<(), Error>
 where
     S: tokio::io::AsyncWrite + std::marker::Unpin,
@@ -493,9 +493,20 @@ where
         }
     };
 
-    let mut buf = vec![0u8; len as usize - 4];
+    let mut bytes = BytesMut::with_capacity(len as usize + 1);
 
-    match stream.read_exact(&mut buf).await {
+    bytes.put_u8(code);
+    bytes.put_i32(len);
+
+    bytes.resize(bytes.len() + len as usize - mem::size_of::<i32>(), b'0');
+
+    match stream
+        .read_exact(
+            &mut bytes[mem::size_of::<u8>() + mem::size_of::<i32>()
+                ..mem::size_of::<u8>() + mem::size_of::<i32>() + len as usize - mem::size_of::<i32>()],
+        )
+        .await
+    {
         Ok(_) => (),
         Err(_) => {
             return Err(Error::SocketError(format!(
@@ -504,12 +515,6 @@ where
             )))
         }
     };
-
-    let mut bytes = BytesMut::with_capacity(len as usize + 1);
-
-    bytes.put_u8(code);
-    bytes.put_i32(len);
-    bytes.put_slice(&buf);
 
     Ok(bytes)
 }


### PR DESCRIPTION
`pgbench -t 1000 -c 16 -j 2 --protocol extended -C`:
### PR:
Stats {
    allocations: 3873384,
    deallocations: 3870448,
    reallocations: 130708,
    bytes_allocated: 497650190,
    bytes_deallocated: 496466494,
    bytes_reallocated: 3722992,
}
### Original:
Stats {
    allocations: 4578799,
    deallocations: 4575881,
    reallocations: 130689,
    bytes_allocated: 509003135,
    bytes_deallocated: 507846373,
    bytes_reallocated: 3716031,
}

**Results in about a 15% decrease in allocations**

`pgbench -t 1000 -c 16 -j 2 --protocol extended`:
### PR
Stats {
    allocations: 2656700,
    deallocations: 2653782,
    reallocations: 2808,
    bytes_allocated: 65691251,
    bytes_deallocated: 64544049,
    bytes_reallocated: 742898,
}

### Original
STATS: Stats {
    allocations: 3361868,
    deallocations: 3358897,
    reallocations: 2863,
    bytes_allocated: 77151598,
    bytes_deallocated: 75935794,
    bytes_reallocated: 757720,
}

**Results in about a 20% decrease in allocations**