### PR TITLE
Removes message cloning operation required for query router

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -693,11 +693,11 @@ where
             let current_shard = query_router.shard();
 
             // Handle all custom protocol commands, if any.
-            match query_router.try_execute_command(message.clone()) {
+            match query_router.try_execute_command(&message) {
                 // Normal query, not a custom command.
                 None => {
                     if query_router.query_parser_enabled() {
-                        query_router.infer(message.clone());
+                        query_router.infer(&message);
                     }
                 }
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -13,4 +13,5 @@ pub enum Error {
     TlsError,
     StatementTimeout,
     ShuttingDown,
+    ParseBytesError(String),
 }

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -7,6 +7,7 @@ use tokio::net::TcpStream;
 
 use crate::errors::Error;
 use std::collections::HashMap;
+use std::io::{BufRead, Cursor};
 use std::mem;
 
 /// Postgres data type mappings
@@ -535,4 +536,21 @@ pub fn server_parameter_message(key: &str, value: &str) -> BytesMut {
     server_info.put_bytes(0, 1);
 
     server_info
+}
+
+pub trait BytesMutReader {
+    fn read_string(&mut self) -> Result<String, Error>;
+}
+
+impl BytesMutReader for Cursor<&BytesMut> {
+    /// Should only be used when reading strings from the message protocol.
+    ///
+    /// Can be used to read multiple strings from the same message which are separated by the null byte
+    fn read_string(&mut self) -> Result<String, Error> {
+        let mut buf = vec![];
+        match self.read_until(b'\0', &mut buf) {
+            Ok(_) => Ok(String::from_utf8_lossy(&buf[..buf.len() - 1]).to_string()),
+            Err(err) => return Err(Error::ParseBytesError(err.to_string())),
+        }
+    }
 }

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -544,7 +544,6 @@ pub trait BytesMutReader {
 
 impl BytesMutReader for Cursor<&BytesMut> {
     /// Should only be used when reading strings from the message protocol.
-    ///
     /// Can be used to read multiple strings from the same message which are separated by the null byte
     fn read_string(&mut self) -> Result<String, Error> {
         let mut buf = vec![];

--- a/src/query_router.rs
+++ b/src/query_router.rs
@@ -260,7 +260,7 @@ impl QueryRouter {
     }
 
     /// Try to infer which server to connect to based on the contents of the query.
-    pub fn infer(&mut self, mut message_buffer: &BytesMut) -> bool {
+    pub fn infer(&mut self, message_buffer: &BytesMut) -> bool {
         debug!("Inferring role");
 
         let mut message_cursor = Cursor::new(message_buffer);

--- a/tests/ruby/load_balancing_spec.rb
+++ b/tests/ruby/load_balancing_spec.rb
@@ -93,7 +93,7 @@ describe "Least Outstanding Queries Load Balancing" do
       threads = Array.new(slow_query_count) do
         Thread.new do
           conn = PG.connect(processes.pgcat.connection_string("sharded_db", "sharding_user"))
-          conn.async_exec("SELECT pg_sleep(1)")
+          conn.async_exec("BEGIN")
         end
       end
 


### PR DESCRIPTION
The client currently needs to clone every message to determine if it is an admin command. This PR removes the need to clone and instead allows passing by reference.

Introduces the BytesMutReader trait to Cursor which helps to read null terminated chunks of strings.