### PR TITLE
Support multiple SASL auth mechanisms

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -158,9 +158,12 @@ impl Server {
                                 Err(_) => return Err(Error::SocketError(format!("Error reading sasl message on server startup {{ username: {:?}, database: {:?} }}", user.username, database))),
                             };
 
-                            let sasl_type = String::from_utf8_lossy(&sasl_auth[..sasl_len - 2]);
+                            let sasl_types: Vec<_> = sasl_auth[..sasl_len - 2]
+                                .split(|&b| b == 0)
+                                .map(|v| String::from_utf8_lossy(v).to_string())
+                                .collect();
 
-                            if sasl_type == SCRAM_SHA_256 {
+                            if sasl_types.contains(&SCRAM_SHA_256.to_string()) {
                                 debug!("Using {}", SCRAM_SHA_256);
 
                                 // Generate client message.
@@ -185,7 +188,7 @@ impl Server {
 
                                 write_all(&mut stream, res).await?;
                             } else {
-                                error!("Unsupported SCRAM version: {}", sasl_type);
+                                error!("Unsupported SCRAM version: {:?}", sasl_types);
                                 return Err(Error::ServerError);
                             }
                         }


### PR DESCRIPTION
Based on [PostgreSQL message format](https://www.postgresql.org/docs/current/protocol-message-formats.html), there could be multiple SASL authentication mechanisms. When connecting to a backend with SSL enabled, PostgreSQL will respond two SASL mechanisms: `SCRAM-SHA-256-PLUS` and `SCRAM-SHA-256`.