### PR TITLE
Fix code coverage + less flakiness

### DIFF
--- a/.circleci/generate_coverage.sh
+++ b/.circleci/generate_coverage.sh
@@ -1,7 +1,15 @@
 #!/bin/bash
 
+# inspired by https://doc.rust-lang.org/rustc/instrument-coverage.html#tips-for-listing-the-binaries-automatically
+TEST_OBJECTS=$( \
+    for file in $(cargo test --no-run 2>&1 | grep "target/debug/deps/pgcat-[[:alnum:]]\+" -o); \
+    do \
+        printf "%s %s " --object $file; \
+    done \
+)
+
 rust-profdata merge -sparse pgcat-*.profraw -o pgcat.profdata
 
-rust-cov export -ignore-filename-regex="rustc|registry" -Xdemangler=rustfilt -instr-profile=pgcat.profdata --object ./target/debug/pgcat --format lcov > ./lcov.info
+bash -c "rust-cov export -ignore-filename-regex='rustc|registry' -Xdemangler=rustfilt -instr-profile=pgcat.profdata $TEST_OBJECTS --object ./target/debug/pgcat --format lcov > ./lcov.info"
 
 genhtml lcov.info --output-directory /tmp/cov --prefix $(pwd)

--- a/tests/ruby/helpers/pgcat_process.rb
+++ b/tests/ruby/helpers/pgcat_process.rb
@@ -8,7 +8,11 @@ class PgcatProcess
   attr_reader :pid
 
   def self.finalize(pid, log_filename, config_filename)
-    `kill #{pid}` if pid
+    if pid
+      Process.kill("TERM", pid)
+      Process.wait(pid)
+    end
+
     File.delete(config_filename) if File.exist?(config_filename)
     File.delete(log_filename) if File.exist?(log_filename)
   end
@@ -77,8 +81,8 @@ class PgcatProcess
   def stop
     return unless @pid
 
-    `kill #{@pid}`
-    sleep 0.1
+    Process.kill("TERM", @pid)
+    Process.wait(@pid)
     @pid = nil
   end
 


### PR DESCRIPTION
Code coverage logic was missing coverage from rust tests. This is now fixed.
Also, we weren't reaping spawned PgCat processes correctly which left zombie processes. 