### PR TITLE
Bake toxiproxy in CI image

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -6,3 +6,5 @@ RUN cargo install cargo-binutils rustfilt && \
 	rustup component add llvm-tools-preview
 RUN pip3 install psycopg2 && \
 	sudo gem install bundler
+RUN wget -O toxiproxy-2.4.0.deb https://github.com/Shopify/toxiproxy/releases/download/v2.4.0/toxiproxy_2.4.0_linux_$(dpkg --print-architecture).deb && \
+	sudo dpkg -i toxiproxy-2.4.0.deb


### PR DESCRIPTION
Instead of downloading Toxiproxy everytime we run CI, we bake it into the CI docker image