### PR TITLE
Move toxiproxy.deb to /tmp

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -8,5 +8,5 @@ RUN sudo apt-get update && \
 	cargo install cargo-binutils rustfilt && \
 	rustup component add llvm-tools-preview && \
  	pip3 install psycopg2 && sudo gem install bundler && \
-	wget -O toxiproxy-2.4.0.deb https://github.com/Shopify/toxiproxy/releases/download/v2.4.0/toxiproxy_2.4.0_linux_$(dpkg --print-architecture).deb && \
-	sudo dpkg -i toxiproxy-2.4.0.deb
+	wget -O /tmp/toxiproxy-2.4.0.deb https://github.com/Shopify/toxiproxy/releases/download/v2.4.0/toxiproxy_2.4.0_linux_$(dpkg --print-architecture).deb && \
+	sudo dpkg -i /tmp/toxiproxy-2.4.0.deb


### PR DESCRIPTION
I am seeing `Directory (/home/circleci/project) you are trying to checkout to is not empty and not a git repository` error after I started using the new `Dockerfile.ci` image. My best guess is that this failure is because we download toxiproxy.deb file into the home directory which blocks git checkout. 

This PR moves toxiproxy to `/tmp/` to avoid this