### PR TITLE
Add psmisc to CI image

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,7 +1,7 @@
 FROM cimg/rust:1.62.0
 RUN sudo apt-get update && \
 	sudo apt-get install -y \
-		postgresql-contrib-12 postgresql-client-12 libpq-dev \
+		psmisc postgresql-contrib-12 postgresql-client-12 libpq-dev \
 		ruby ruby-dev python3 python3-pip \
 		lcov llvm-11 iproute2 && \
 	sudo apt-get upgrade curl && \


### PR DESCRIPTION
I accidentally removed `psmisc` from the image and now the test builds are failing. I am adding it back in this PR