### PR TITLE
implement show users

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 /target
 *.deb
 .vscode
+.profraw
+cov/
+lcov.info

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -676,7 +676,7 @@ async fn show_users<T>(stream: &mut T) -> Result<(), Error>
 where
     T: tokio::io::AsyncWrite + std::marker::Unpin,
 {
-    let res = BytesMut::new();
+    let mut res = BytesMut::new();
 
     res.put(row_description(&vec![
         ("name", DataType::Text),
@@ -685,8 +685,10 @@ where
 
     for (user_pool, pool) in get_all_pools() {
         let pool_config = &pool.settings;
-        let mut row = vec![user_pool.user.clone(), pool_config.pool_mode.to_string()];
-        res.put(data_row(&row));
+        res.put(data_row(&vec![
+            user_pool.user.clone(),
+            pool_config.pool_mode.to_string(),
+        ]));
     }
 
     res.put(command_complete("SHOW"));

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -100,6 +100,10 @@ where
                 trace!("SHOW VERSION");
                 show_version(stream).await
             }
+            "USERS" => {
+                trace!("SHOW USERS");
+                show_users(stream).await
+            }
             _ => error_response(stream, "Unsupported SHOW query against the admin database").await,
         },
         _ => error_response(stream, "Unsupported query against the admin database").await,
@@ -665,4 +669,31 @@ where
             }
         }
     }
+}
+
+/// Show Users.
+async fn show_users<T>(stream: &mut T) -> Result<(), Error>
+where
+    T: tokio::io::AsyncWrite + std::marker::Unpin,
+{
+    let res = BytesMut::new();
+
+    res.put(row_description(&vec![
+        ("name", DataType::Text),
+        ("pool_mode", DataType::Text),
+    ]));
+
+    for (user_pool, pool) in get_all_pools() {
+        let pool_config = &pool.settings;
+        let mut row = vec![user_pool.user.clone(), pool_config.pool_mode.to_string()];
+        res.put(data_row(&row));
+    }
+
+    res.put(command_complete("SHOW"));
+
+    res.put_u8(b'Z');
+    res.put_i32(5);
+    res.put_u8(b'I');
+
+    write_all_half(stream, &res).await
 }

--- a/tests/ruby/admin_spec.rb
+++ b/tests/ruby/admin_spec.rb
@@ -286,4 +286,14 @@ describe "Admin" do
       connections.map(&:close)
     end
   end
+
+  describe "SHOW users" do
+    it "returns the right users" do
+      admin_conn = PG::connect(processes.pgcat.admin_connection_string)
+      results = admin_conn.async_exec("SHOW USERS")[0]
+      admin_conn.close
+      expect(results["name"]).to eq("sharding_user")
+      expect(results["pool_mode"]).to eq("transaction")
+    end
+  end
 end


### PR DESCRIPTION
I noticed that this admin query wasn't supported. My company is gradually switching over from pgbouncer to pgcat and I want this transition to be relatively smooth. We'll likely implement pgcat specific features in our tooling but for now I want there to be less hiccups.

```
pgcat=> show users;
FATAL:  Unsupported SHOW query against the admin database
```