### PR TITLE
Allow sending logs to stdout by using STDOUT_LOG env var

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ pub mod server;
 pub mod sharding;
 pub mod stats;
 pub mod tls;
+pub mod multi_logger;
 
 /// Format chrono::Duration to be more human-friendly.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,13 +2,13 @@ pub mod config;
 pub mod constants;
 pub mod errors;
 pub mod messages;
+pub mod multi_logger;
 pub mod pool;
 pub mod scram;
 pub mod server;
 pub mod sharding;
 pub mod stats;
 pub mod tls;
-pub mod multi_logger;
 
 /// Format chrono::Duration to be more human-friendly.
 ///

--- a/src/main.rs
+++ b/src/main.rs
@@ -66,6 +66,7 @@ mod config;
 mod constants;
 mod errors;
 mod messages;
+mod multi_logger;
 mod pool;
 mod prometheus;
 mod query_router;
@@ -74,7 +75,6 @@ mod server;
 mod sharding;
 mod stats;
 mod tls;
-mod multi_logger;
 
 use crate::config::{get_config, reload_config, VERSION};
 use crate::pool::{ClientServerMap, ConnectionPool};
@@ -161,7 +161,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         let client_server_map: ClientServerMap = Arc::new(Mutex::new(HashMap::new()));
 
         // Statistics reporting.
-        let (stats_tx, stats_rx) = mpsc::channel(100_000);
+        let (stats_tx, stats_rx) = mpsc::channel(500_000);
         REPORTER.store(Arc::new(Reporter::new(stats_tx.clone())));
 
         // Connection pool that allows to query all shards and replicas.

--- a/src/main.rs
+++ b/src/main.rs
@@ -74,6 +74,7 @@ mod server;
 mod sharding;
 mod stats;
 mod tls;
+mod multi_logger;
 
 use crate::config::{get_config, reload_config, VERSION};
 use crate::pool::{ClientServerMap, ConnectionPool};
@@ -81,7 +82,7 @@ use crate::prometheus::start_metric_server;
 use crate::stats::{Collector, Reporter, REPORTER};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    env_logger::builder().format_timestamp_micros().init();
+    multi_logger::MultiLogger::init().unwrap();
 
     info!("Welcome to PgCat! Meow. (Version {})", VERSION);
 

--- a/src/multi_logger.rs
+++ b/src/multi_logger.rs
@@ -1,0 +1,80 @@
+use log::{Level, Log, Metadata, Record, SetLoggerError};
+
+// This is a special kind of logger that allows sending logs to different
+// targets depending on the log level.
+//
+// By default, if nothing is set, it acts as a regular env_log logger,
+// it sends everything to standard error.
+//
+// If the Env variable `STDOUT_LOG` is defined, it will be used for
+// configuring the standard out logger.
+//
+// The behavior is:
+//   - If it is an error, the message is written to standard error.
+//   - If it is not, and it matches the log level of the standard output logger (`STDOUT_LOG` env var), it will be send to standard output.
+//   - If the above is not true, it is sent to the stderr logger that will log it or not depending on the value
+//     of the RUST_LOG env var.
+//
+// So to summarize, if no `STDOUT_LOG` env var is present, the logger is the default logger. If STDOUT_LOG is set, everything
+// but errors, that matches the log level set in the STDOUT_LOG env var is sent to stdout. You can have also some esoteric configuration
+// where you set `RUST_LOG=debug` and `STDOUT_LOG=info`, in here, erros will go to stderr, warns and infos to stdout and debugs to stderr.
+//
+pub struct MultiLogger {
+    stderr_logger: env_logger::Logger,
+    stdout_logger: env_logger::Logger,
+}
+
+impl MultiLogger {
+    fn new() -> Self {
+        let stderr_logger = env_logger::builder().format_timestamp_micros().build();
+        let stdout_logger = env_logger::Builder::from_env("STDOUT_LOG")
+            .format_timestamp_micros()
+            .target(env_logger::Target::Stdout)
+            .build();
+
+        Self {
+            stderr_logger,
+            stdout_logger,
+        }
+    }
+
+    pub fn init() -> Result<(), SetLoggerError> {
+        let logger = Self::new();
+
+        log::set_max_level(logger.stderr_logger.filter());
+        log::set_boxed_logger(Box::new(logger))
+    }
+}
+
+impl Log for MultiLogger {
+    fn enabled(&self, metadata: &Metadata) -> bool {
+        self.stderr_logger.enabled(metadata) && self.stdout_logger.enabled(metadata)
+    }
+
+    fn log(&self, record: &Record) {
+        if record.level() == Level::Error {
+            self.stderr_logger.log(record);
+        } else {
+            if self.stdout_logger.matches(record) {
+                self.stdout_logger.log(record);
+            } else {
+                self.stderr_logger.log(record);
+            }
+        }
+    }
+
+    fn flush(&self) {
+        self.stderr_logger.flush();
+        self.stdout_logger.flush();
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_init() {
+        MultiLogger::init().unwrap();
+    }
+}

--- a/src/multi_logger.rs
+++ b/src/multi_logger.rs
@@ -15,8 +15,8 @@ use log::{Level, Log, Metadata, Record, SetLoggerError};
 //   - If the above is not true, it is sent to the stderr logger that will log it or not depending on the value
 //     of the RUST_LOG env var.
 //
-// So to summarize, if no `STDOUT_LOG` env var is present, the logger is the default logger. If STDOUT_LOG is set, everything
-// but errors, that matches the log level set in the STDOUT_LOG env var is sent to stdout. You can have also some esoteric configuration
+// So to summarize, if no `STDOUT_LOG` env var is present, the logger is the default logger. If `STDOUT_LOG` is set, everything
+// but errors, that matches the log level set in the `STDOUT_LOG` env var is sent to stdout. You can have also some esoteric configuration
 // where you set `RUST_LOG=debug` and `STDOUT_LOG=info`, in here, erros will go to stderr, warns and infos to stdout and debugs to stderr.
 //
 pub struct MultiLogger {


### PR DESCRIPTION
Hi!

We are currently using PgCat in production :woman_dancing: (at least for some hours already), thanks for the good work!.

 There are two things that have came up during the deployment:

- Logs are all written to stderr: We expect error logging to go to stderr and warns/info/etc to stdout. This is because we monitor the output of every piece of software we run and have set alarms to check whether there is an increase in the error logging. Current logging implementation does not allow a fine grained control over this.

- Stats filled out the buffer: There is a buffer for sending stats in the code, it is currently set to 100_000. When we started using this, during peaks of traffic, this buffer filled up and led the system into an inconsistent state and a flood of 
`
[2023-02-23T12:09:59.609264Z WARN  pgcat::stats] Got event ServerActive { client_id: 1612304972, server_id: 1350173897 } for unregistered server
` Started. Our current implementation reaches 100k clients connected to 4 different instances of pgcat, so at high traffic, that buffer can fill up.

We propose a solution here where the log can be configured to log to stdout (maintaining backward compatibility), and also where the buffer is increased (by 5).

## Logging mechanism

The idea was to use a special kind of logger that allows sending logs to different targets depending on the log level.

By default, if nothing is set, it acts as a regular env_log logger, it sends everything to standard error.

If the Env variable `STDOUT_LOG` is defined, it will be used for configuring the standard out logger.

The behavior is:
   - If it is an error, the message is written to standard error.
   - If it is not, and it matches the log level of the standard output logger (`STDOUT_LOG` env var), it will be send to standard output.
   - If the above is not true, it is sent to the stderr logger that will log it or not depending on the value
     of the RUST_LOG env var.

 So to summarize, if no `STDOUT_LOG` env var is present, the logger is the default logger. If `STDOUT_LOG` is set, everything but errors, that matches the log level set in the `STDOUT_LOG` env var is sent to stdout. You can have also some esoteric configuration where you set `RUST_LOG=debug` and `STDOUT_LOG=info`, in here, erros will go to stderr, warns and infos to stdout and debugs to stderr.

In a previous contribution I was said that 'We are not supporting env vars for configuration yet' but given that this is a special case, because is the log system I implemented it this way. If you think the name of the ENV var is not the right one, or have another proposal for the implementation just let me know. Still, independently of the implementation, I think logging everything to stderr is not flexive enough, actually that's why stderr/stdout exists.

If we agree on a merge, I'll write documentation on the README for whaver was agreed upon.
