### PR TITLE
Automatic sharding for SELECT v2

### DIFF
--- a/pgcat.toml
+++ b/pgcat.toml
@@ -102,7 +102,7 @@ primary_reads_enabled = true
 sharding_function = "pg_bigint_hash"
 
 # Automatically parse this from queries and route queries to the right shard!
-automatic_sharding_key = "id"
+automatic_sharding_key = "data.id"
 
 # Idle timeout can be overwritten in the pool
 idle_timeout = 40000

--- a/src/config.rs
+++ b/src/config.rs
@@ -416,6 +416,8 @@ impl Pool {
 
         self.automatic_sharding_key = match &self.automatic_sharding_key {
             Some(key) => {
+                // No quotes in the key so we don't have to compare quoted
+                // to unquoted idents.
                 let key = key.replace("\"", "");
 
                 if key.split(".").count() != 2 {

--- a/src/config.rs
+++ b/src/config.rs
@@ -374,7 +374,7 @@ impl Pool {
         None
     }
 
-    pub fn validate(&self) -> Result<(), Error> {
+    pub fn validate(&mut self) -> Result<(), Error> {
         match self.default_role.as_ref() {
             "any" => (),
             "primary" => (),
@@ -413,6 +413,23 @@ impl Pool {
                 }
             }
         }
+
+        self.automatic_sharding_key = match &self.automatic_sharding_key {
+            Some(key) => {
+                let key = key.replace("\"", "");
+
+                if key.split(".").count() != 2 {
+                    error!(
+                        "automatic_sharding_key '{}' must be fully qualified, e.g. t.{}`",
+                        key, key
+                    );
+                    return Err(Error::BadConfig);
+                }
+
+                Some(key)
+            }
+            None => None,
+        };
 
         Ok(())
     }


### PR DESCRIPTION
Make the `SELECT` automatic sharding better:

1. Require a fully qualified sharding key to make sure a generic one like `id` doesn't just shard all tables differently.
2. Allow for a unique enough non-fully qualified sharding key, e.g. `user_id`.
3. Add support for parsing `INNER JOIN` (more to come, just need to add more to the match statement).
4. Overall, more correct implementation handing more cases.

### Examples

```toml
automatic_sharding_key = "t.id"
```

```postgresql
SELECT * FROM t1 WHERE id = 5; -- Not fully qualified but unambiguous is fine

SELECT * FROM t1 INNER JOIN t2 ON t1.id = 5 AND t1.id = t2.id; -- Filtering in join is fine

SELECT * FROM public.t1  NATURAL JOIN t2 WHERE t1.id = 5; -- Fully qualified is fine
```

### TODOs (PRs welcome)

Support for extended protocol (anonymous prepared statements). Requires a bit of state management (parse offsets in `B` instead of values from `Q`).

Support for more join types (easy, just add more match arms).

Support for INSERTs, should be pretty easy as well, just parse the values and ensure there is only one sharding key. Works ok for single value inserts (the most common), but bulk and COPY will require connecting to multiple shards, which will be super cool but needs more work.

@jmeagher FYI, I think this could be the next iteration after Regex parsing of comments. This will allow the pooler to handle sharding without any client modifications. Still a work in progress, and will need to test for a lot of use cases, but if the sharding key is unique enough, e.g. `user_id`, as long as it appears in the query with a value, we should be confident enough we'll get the right shard.