### PR TITLE
Check Slice bounds in read_message to avoid panics

### DIFF
--- a/src/messages.rs
+++ b/src/messages.rs
@@ -517,12 +517,19 @@ where
 
     bytes.resize(bytes.len() + len as usize - mem::size_of::<i32>(), b'0');
 
+    let slice_start = mem::size_of::<u8>() + mem::size_of::<i32>();
+    let slice_end = slice_start + len as usize - mem::size_of::<i32>();
+
+    // Avoids a panic
+    if slice_end < slice_start {
+        return Err(Error::SocketError(format!(
+            "Error reading message from socket - Code: {:?} - Length {:?}, Error: {:?}",
+            code, len, "Unexpected length value for message"
+        )));
+    }
+
     match stream
-        .read_exact(
-            &mut bytes[mem::size_of::<u8>() + mem::size_of::<i32>()
-                ..mem::size_of::<u8>() + mem::size_of::<i32>() + len as usize
-                    - mem::size_of::<i32>()],
-        )
+        .read_exact(&mut bytes[slice_start..slice_end])
         .await
     {
         Ok(_) => (),

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -528,10 +528,7 @@ where
         )));
     }
 
-    match stream
-        .read_exact(&mut bytes[slice_start..slice_end])
-        .await
-    {
+    match stream.read_exact(&mut bytes[slice_start..slice_end]).await {
         Ok(_) => (),
         Err(err) => {
             return Err(Error::SocketError(format!(


### PR DESCRIPTION
When `recv` is called in the mirroring client, we noticed an occasional panic when reading the message. 

```
thread 'tokio-runtime-worker' panicked at 'slice index starts at 5 but ends at 0', src/messages.rs:522:18
```
We are still debugging the reason why this happens but adding a check for slice bounds seems like a good idea. Instead of panicking, this will return an `Err` to the caller which will close the connection.

